### PR TITLE
Move into the correct package after the move.

### DIFF
--- a/cmd/services/main.go
+++ b/cmd/services/main.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/bigkevmcd/services/pkg/avancement"
-	"github.com/bigkevmcd/services/pkg/git"
 	"github.com/mitchellh/go-homedir"
+	"github.com/rhd-gitops-example/services/pkg/avancement"
+	"github.com/rhd-gitops-example/services/pkg/git"
 	"github.com/tcnksm/go-gitconfig"
 	"github.com/urfave/cli/v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bigkevmcd/services
+module github.com/rhd-gitops-example/services
 
 go 1.13
 
@@ -12,5 +12,4 @@ require (
 	github.com/urfave/cli/v2 v2.1.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	gopkg.in/src-d/go-git.v4 v4.13.1
-	gopkg.in/yaml.v2 v2.2.2
 )

--- a/pkg/avancement/pull_request.go
+++ b/pkg/avancement/pull_request.go
@@ -3,8 +3,8 @@ package avancement
 import (
 	"fmt"
 
-	"github.com/bigkevmcd/services/pkg/util"
 	"github.com/jenkins-x/go-scm/scm"
+	"github.com/rhd-gitops-example/services/pkg/util"
 )
 
 // TODO: OptionFuncs for Base and Title?

--- a/pkg/avancement/service_manager.go
+++ b/pkg/avancement/service_manager.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/jenkins-x/go-scm/scm"
 
-	"github.com/bigkevmcd/services/pkg/git"
-	"github.com/bigkevmcd/services/pkg/util"
+	"github.com/rhd-gitops-example/services/pkg/git"
+	"github.com/rhd-gitops-example/services/pkg/util"
 )
 
 type ServiceManager struct {

--- a/pkg/avancement/service_manager_test.go
+++ b/pkg/avancement/service_manager_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm"
 	fakescm "github.com/jenkins-x/go-scm/scm/driver/fake"
 
-	"github.com/bigkevmcd/services/pkg/git/mock"
+	"github.com/rhd-gitops-example/services/pkg/git/mock"
 )
 
 const (

--- a/pkg/git/mock/mock_test.go
+++ b/pkg/git/mock/mock_test.go
@@ -1,5 +1,5 @@
 package mock
 
-import "github.com/bigkevmcd/services/pkg/git"
+import "github.com/rhd-gitops-example/services/pkg/git"
 
 var _ git.Cache = (*MockCache)(nil)


### PR DESCRIPTION
Now that the code is sitting in rhd-gitops-example, the Go package names need to be updated.