### PR TITLE
Tweak tests for standard repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a pre-alpha PoC for promoting versions of files between environments, re
 
 ## Building
 
+You need Go version 1.14 to build this project.
+
 ```shell
 $ go build ./cmd/services
 ```


### PR DESCRIPTION
I've updated the tests so that they function against a test repo with the desired file structure. This is part of https://github.com/rhd-gitops-example/services/issues/2 : the next task is to update `promote --service` so as to expect a services/ top level directory. 