### PR TITLE
add git in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /go/build
 RUN go build ./cmd/services
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+RUN microdnf install git
 WORKDIR /root/
 COPY --from=build /go/build/services /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/services"]


### PR DESCRIPTION
The git executable is necessary for the promote but it doesn't exist.
`microdnf install git` adds the git version 2.18.2. 