### PR TITLE
Add debug log output for execGit.

### DIFF
--- a/cmd/services/main.go
+++ b/cmd/services/main.go
@@ -7,10 +7,11 @@ import (
 	"os"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/rhd-gitops-example/services/pkg/avancement"
-	"github.com/rhd-gitops-example/services/pkg/git"
 	"github.com/tcnksm/go-gitconfig"
 	"github.com/urfave/cli/v2"
+
+	"github.com/rhd-gitops-example/services/pkg/avancement"
+	"github.com/rhd-gitops-example/services/pkg/git"
 )
 
 const (
@@ -22,6 +23,7 @@ const (
 	cacheDirFlag    = "cache-dir"
 	nameFlag        = "commit-name"
 	emailFlag       = "commit-email"
+	debugFlag       = "debug"
 )
 
 var (
@@ -31,6 +33,13 @@ var (
 			Usage:    "oauth access token to authenticate the request",
 			EnvVars:  []string{"GITHUB_TOKEN"},
 			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:     debugFlag,
+			Usage:    "additional debug logging output",
+			EnvVars:  []string{"DEBUG_SERVICES"},
+			Value:    false,
+			Required: false,
 		},
 	}
 
@@ -103,6 +112,7 @@ func promoteAction(c *cli.Context) error {
 	toRepo := c.String(toFlag)
 	service := c.String(serviceFlag)
 	newBranchName := c.String(branchNameFlag)
+	debug := c.Bool(debugFlag)
 
 	cacheDir, err := homedir.Expand(c.String(cacheDirFlag))
 	if err != nil {
@@ -113,7 +123,7 @@ func promoteAction(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return avancement.New(cacheDir, author).Promote(service, fromRepo, toRepo, newBranchName)
+	return avancement.New(cacheDir, author, avancement.WithDebug(debug)).Promote(service, fromRepo, toRepo, newBranchName)
 }
 
 func newAuthor(c *cli.Context) (*git.Author, error) {

--- a/pkg/avancement/service_manager_test.go
+++ b/pkg/avancement/service_manager_test.go
@@ -28,7 +28,7 @@ func TestPromoteWithSuccess(t *testing.T) {
 	}
 	sm := New("tmp", author)
 	sm.clientFactory = fakeClientFactory
-	sm.repoFactory = func(url, _ string) (git.Repo, error) {
+	sm.repoFactory = func(url, _ string, _ bool) (git.Repo, error) {
 		return git.Repo(repos[url]), nil
 	}
 	devRepo.AddFiles("/services/my-service/base/config/myfile.yaml")


### PR DESCRIPTION
```
$ ./services --debug promote --from github.com/bigkevmcd/env-dev.git --to https://github.com/bigkevmcd/env-staging --service service-a
2020/03/31 10:57:15 fatal: repository 'github.com/bigkevmcd/env-dev.git' does not exist

2020/03/31 10:57:15 failed to clone source repo github.com/bigkevmcd/env-dev.git: exit status 128
```

Note that `--debug` is a "top-level" option, not specific to promote, so, `--debug` before `promote`.