### PR TITLE
Don't surface access tokens for any error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-./services
+services

--- a/pkg/avancement/service_manager_test.go
+++ b/pkg/avancement/service_manager_test.go
@@ -13,6 +13,7 @@ import (
 	fakescm "github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/rhd-gitops-example/services/pkg/git"
 	"github.com/rhd-gitops-example/services/pkg/git/mock"
+	"github.com/rhd-gitops-example/services/test"
 )
 
 const (
@@ -253,4 +254,27 @@ func (s *mockSource) AddFiles(name string) {
 		s.files = []string{}
 	}
 	s.files = append(s.files, path.Join(s.localPath, name))
+}
+
+func TestRepositoryCloneErrorOmitsToken(t *testing.T) {
+	dstBranch := "test-branch"
+	author := &git.Author{Name: "Testing User", Email: "testing@example.com", Token: "test-token"}
+	client, _ := fakescm.NewDefault()
+	fakeClientFactory := func(s string) *scm.Client {
+		return client
+	}
+	sm := New("tmp", author)
+	sm.clientFactory = fakeClientFactory
+
+	sm.repoFactory = func(url, _ string, _ bool) (git.Repo, error) {
+		// This actually causes the error and results in trying to create a repository
+		// which can surface the token
+		errorMessage := fmt.Errorf("failed to clone repository %s: exit status 128", dev)
+		return nil, errorMessage
+	}
+	err := sm.Promote("my-service", dev, staging, dstBranch, "", false)
+	if err != nil {
+		devRepoToUseInError := fmt.Sprintf(".*%s", dev)
+		test.AssertErrorMatch(t, devRepoToUseInError, err)
+	}
 }

--- a/pkg/git/errors.go
+++ b/pkg/git/errors.go
@@ -1,0 +1,46 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// We can choose to throw one of these errors if we want to handle it
+// in a particularly special way. This will be useful for Git API calls where
+// we know there's going to be a repository URL involved and it's not
+// some other error (e.g. to do with file permissions)
+type gitError struct {
+	msg string
+}
+
+// GitError returns an error whereby the user part of the url is removed (e.g. an access token)
+// Accepts the message to use and the url to remove the user part from
+func GitError(msg, url string) error {
+	cleanedURL, err := CleanURL(url)
+	if err != nil {
+		return err
+	}
+	return gitError{msg: fmt.Sprintf("%s. repository URL = %s", msg, cleanedURL)}
+}
+
+// IsGitError performs a cast to see if an error really is of type gitError
+func IsGitError(err error) bool {
+	_, ok := err.(gitError)
+	return ok
+}
+
+// CleanURL removes the .User part of the string (typically an access token)
+func CleanURL(inputURL string) (string, error) {
+	parsedURL, parseErr := url.Parse(inputURL)
+	if parseErr != nil {
+		// Intentionally don't display any real parse error as it would contain any token
+		return "", errors.New("failed to parse git repository URL, check it's well-formed")
+	}
+	parsedURL.User = nil
+	return parsedURL.String(), nil
+}
+
+func (e gitError) Error() string {
+	return e.msg
+}

--- a/pkg/git/errors_test.go
+++ b/pkg/git/errors_test.go
@@ -1,0 +1,25 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanURLRemovesTokenFromError(t *testing.T) {
+	url := "https://mytoken@github.com/my-repo"
+	cleanedURL, err := CleanURL(url)
+	if err != nil {
+		t.Fatal("got an error cleaning a well-formed URL")
+	}
+	if strings.Contains(cleanedURL, "mytoken") {
+		t.Fatal("error still contains access token")
+	}
+}
+
+func TestCleanURLThrowsErrorIfInvalidURL(t *testing.T) {
+	url := ":_ https://mytoken@github.com/my-repo"
+	cleanedURL, err := CleanURL(url)
+	if err == nil {
+		t.Fatalf("did not get an an error cleaning a bad URL, cleaned URL is: %s", cleanedURL)
+	}
+}

--- a/pkg/git/repository_test.go
+++ b/pkg/git/repository_test.go
@@ -24,7 +24,7 @@ func TestRepoName(t *testing.T) {
 		wantErr  string
 	}{
 		{testRepository, "staging", ""},
-		{"https://github.com/mnuttall", "", "could not identify repo: https://github.com/mnuttall"},
+		{"https://github.com/mnuttall", "", "could not identify repository name: https://github.com/mnuttall"},
 	}
 
 	for _, tt := range nameTests {
@@ -259,7 +259,7 @@ func TestDebugEnabled(t *testing.T) {
 	r, err := NewRepository(testRepository, path.Join(tempDir, "path"), true)
 	assertNoError(t, err)
 	if !r.debug {
-	  t.Fatalf("Debug not set to true")
+		t.Fatalf("Debug not set to true")
 	}
 }
 


### PR DESCRIPTION
For https://github.com/rhd-gitops-example/services/issues/26, here's what I'm thinking so far keeping it as simple as possible.

@bigkevmcd I know you added a .gitignore already but my services binary was still being picked up, curious if yours is too 👀 