### PR TITLE
Move debug to a promote flag instead of a global one

### DIFF
--- a/cmd/services/main.go
+++ b/cmd/services/main.go
@@ -34,13 +34,6 @@ var (
 			EnvVars:  []string{"GITHUB_TOKEN"},
 			Required: true,
 		},
-		&cli.BoolFlag{
-			Name:     debugFlag,
-			Usage:    "additional debug logging output",
-			EnvVars:  []string{"DEBUG_SERVICES"},
-			Value:    false,
-			Required: false,
-		},
 	}
 
 	promoteFlags = []cli.Flag{
@@ -82,6 +75,13 @@ var (
 			Usage:    "the email to use for commits when creating branches",
 			Required: false,
 			EnvVars:  []string{"COMMIT_EMAIL"},
+		},
+		&cli.BoolFlag{
+			Name:     debugFlag,
+			Usage:    "additional debug logging output",
+			EnvVars:  []string{"DEBUG_SERVICES"},
+			Value:    false,
+			Required: false,
 		},
 	}
 )


### PR DESCRIPTION
For: https://github.com/rhd-gitops-example/services/issues/27
- Updates the `--debug` flag to be a promote flag instead of a global one. 
- You can now use the `--debug` flag anywhere after `promote` when doing a promote command instead of only being able to use it at the very start of the command.