### PR TITLE
copy from source repo

### DIFF
--- a/pkg/avancement/pull_request.go
+++ b/pkg/avancement/pull_request.go
@@ -11,11 +11,11 @@ import (
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
 func makePullRequestInput(fromURL, toURL, branchName string) (*scm.PullRequestInput, error) {
-	fromUser, fromRepo, err := util.ExtractUserAndRepo(fromURL)
+	_, fromRepo, err := util.ExtractUserAndRepo(fromURL)
 	if err != nil {
 		return nil, err
 	}
-	_, toRepo, err := util.ExtractUserAndRepo(toURL)
+	fromUser, toRepo, err := util.ExtractUserAndRepo(toURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/avancement/service_manager.go
+++ b/pkg/avancement/service_manager.go
@@ -94,7 +94,7 @@ func (s *ServiceManager) Promote(serviceName, fromURL, toURL, newBranchName stri
 	reposToDelete = append(reposToDelete, destination)
 
 	copied := []string{}
-	if fromSourceRepo(fromURL) {
+	if fromLocalRepo(fromURL) {
 		localSource, err := s.localFactory(fromURL, s.debug) 
 		copied, err = local.CopyConfig(serviceName, localSource, destination)
 		if err != nil {
@@ -205,7 +205,7 @@ func addCredentialsIfNecessary(s string, a *git.Author) (string, error) {
 	parsed.User = url.UserPassword("promotion", a.Token)
 	return parsed.String(), nil
 }
-func fromSourceRepo(s string) bool {
+func fromLocalRepo(s string) bool {
 	parsed, err := url.Parse(s)
 	if err != nil || parsed.Scheme == "" {
 		return true

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -1,0 +1,58 @@
+package local
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"github.com/rhd-gitops-example/services/pkg/git"
+)
+
+
+type Local struct {
+	LocalPath string
+	Debug     bool
+	Logger    func(fmt string, v ...interface{})
+}
+
+
+// CopyConfig takes the name of a service and a Source local service root path to be copied to a Destination.
+//
+// Only files under /path/to/local/repo/config/* are copied to the destination /services/[serviceName]/base/config/* 
+//
+// Returns the list of files that were copied, and possibly an error.
+func CopyConfig(serviceName string, source git.Source, dest git.Destination) ([]string, error) {
+
+	copied := []string{}
+	err := source.Walk("", func(prefix, name string) error {
+		sourcePath := path.Join(prefix, name)
+		destPath := pathForDestServiceConfig(serviceName, name)
+		err := dest.CopyFile(sourcePath, destPath)
+		if err == nil {
+			copied = append(copied, destPath)
+		}
+		return err
+	})
+	return copied, err
+}
+
+// pathForDestServiceConfig defines where in a 'gitops' repository the local config file
+// for a given service should live.
+func pathForDestServiceConfig(serviceName, name string) string {
+	return filepath.Join("services/", serviceName, "base", name)
+}
+
+func (l *Local) Walk(base string, cb func(prefix, name string) error) error {
+	base = filepath.Join(l.LocalPath, "config")
+	prefix := filepath.Dir(base) + "/"
+	return filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+		return cb(prefix, strings.TrimPrefix(path, prefix))
+	})
+}

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -36,7 +36,7 @@ func CopyConfig(serviceName string, source git.Source, dest git.Destination) ([]
 	return copied, err
 }
 
-// pathForDestServiceConfig defines where in a 'gitops' repository the local config file
+// pathForDestServiceConfig defines where in a 'gitops' repository the config
 // for a given service should live.
 func pathForDestServiceConfig(serviceName, name string) string {
 	return filepath.Join("services/", serviceName, "base", name)

--- a/pkg/local/local_test.go
+++ b/pkg/local/local_test.go
@@ -1,0 +1,98 @@
+package local
+
+import (
+	"errors"
+	"io"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCopyConfig(t *testing.T) {
+	s := &mockSource{localPath: "/tmp/testing"}
+	files := []string{"config/my-file.yaml", "config/this-file.yaml"}
+	copiedfiles := []string{"services/service-a/base/config/my-file.yaml", "services/service-a/base/config/this-file.yaml"}
+	for _, f := range files {
+		s.addFile(f)
+	}
+	d := &mockDestination{}
+
+	copied, err := CopyConfig("service-a", s, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.assertFilesWritten(t, copiedfiles)
+	if !reflect.DeepEqual(copiedfiles, copied) {
+		t.Fatalf("failed to copy the files, got %#v, want %#v", copied, files)
+	}
+}
+
+
+type mockSource struct {
+	files     []string
+	localPath string
+}
+
+// Walk: a mock function to emulate what happens in Repository.Walk()
+// The Mock version is different: it iterates over mockSource.files[] and then drives
+// the visitor callback in CopyService() as usual.
+//
+// To preserve the same behaviour, we see that Repository Walk receives /full/path/to/repo/services/service-name
+// and then calls filePath.Walk() on /full/path/to/repo/services/ .
+// When CopyService() drives Walk(), 'base' is typically services/service-name
+// Thus we take each /full/path/to/file/in/mockSource.files[] and split it at 'services/' as happens in the Walk() method we're mocking.
+func (s *mockSource) Walk(base string, cb func(string, string) error) error {
+	if s.files == nil {
+		return nil
+	}
+	base = filepath.Join(s.localPath, "config")
+
+	for _, f := range s.files {
+		splitString := filepath.Dir(base) + "/"
+		splitPoint := strings.Index(f, splitString) + len(splitString)
+		prefix := f[:splitPoint]
+		name := f[splitPoint:]
+		err := cb(prefix, name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *mockSource) addFile(name string) {
+	if s.files == nil {
+		s.files = []string{}
+	}
+	s.files = append(s.files, path.Join(s.localPath, name))
+}
+
+type mockDestination struct {
+	written   []string
+	copyError error
+}
+
+func (d *mockDestination) CopyFile(src, dst string) error {
+	if d.written == nil {
+		d.written = []string{}
+	}
+	if d.copyError != nil {
+		return d.copyError
+	}
+	d.written = append(d.written, dst)
+	return nil
+}
+
+func (d *mockDestination) WriteFile(src io.Reader, dst string) error {
+	return errors.New("not implemented just now")
+}
+
+func (d *mockDestination) assertFilesWritten(t *testing.T, want []string) {
+	if diff := cmp.Diff(want, d.written); diff != "" {
+		t.Fatalf("written files do not match: %s", diff)
+	}
+}


### PR DESCRIPTION
This implements https://github.com/rhd-gitops-example/services/issues/19.

When --from is a local path, it copies `/path/to/local/repo`/config/* to `url.to.target.repo`/services/svc-name/base/config/*.