### PR TITLE
Generate unique branch if one is not specified

### DIFF
--- a/cmd/services/main.go
+++ b/cmd/services/main.go
@@ -56,7 +56,7 @@ var (
 		&cli.StringFlag{
 			Name:  branchNameFlag,
 			Usage: "the name to use for the newly created branch",
-			Value: "test-branch",
+			Value: "",
 		},
 		&cli.StringFlag{
 			Name:     cacheDirFlag,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.3.0
+	github.com/google/uuid v1.1.1
 	github.com/jenkins-x/go-scm v1.5.77
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/h2non/gock v1.0.9 h1:17gCehSo8ZOgEsFKpQgqHiR7VLyjxdAG3lkhVvO9QZU=

--- a/pkg/avancement/service_manager_test.go
+++ b/pkg/avancement/service_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"regexp"
 
 	"github.com/jenkins-x/go-scm/scm"
 	fakescm "github.com/jenkins-x/go-scm/scm/driver/fake"
@@ -172,6 +173,20 @@ func TestPromoteWithCacheDeletionFailure(t *testing.T) {
 
 	stagingRepo.AssertNotDeletedFromCache(t)
 	devRepo.AssertDeletedFromCache(t)
+}
+
+func TestGenerateBranchWithSuccess(t *testing.T) {
+    repo := mock.New("/dev", "master")
+	GenerateBranchWithSuccess(t, repo)
+}
+
+func GenerateBranchWithSuccess(t *testing.T, repo git.Repo) {
+	branch := generateBranch(repo)
+	nameRegEx := "^([0-9A-Za-z]+)-([0-9a-z]{7})-([0-9A-Za-z]{5})$"
+	_, err := regexp.Match(nameRegEx, []byte(branch))
+	if err != nil {
+		t.Fatalf("failed to generate a branch name matching pattern %s", nameRegEx)
+	}
 }
 
 type mockSource struct {

--- a/pkg/git/interface.go
+++ b/pkg/git/interface.go
@@ -20,6 +20,8 @@ type Source interface {
 type Repo interface {
 	Destination
 	Source
+	GetName() string
+	GetCommitID() string
 	Clone() error
 	Checkout(branch string) error
 	CheckoutAndCreate(branch string) error

--- a/pkg/git/mock/mock.go
+++ b/pkg/git/mock/mock.go
@@ -34,6 +34,10 @@ type Repository struct {
 
 	deleted   bool
 	DeleteErr error
+
+	commitID string
+
+	repoName string
 }
 
 // New creates and returns a new git.Cache implementation that operates entirely
@@ -48,6 +52,16 @@ func (m *Repository) Checkout(branch string) error {
 		m.currentBranch = branch
 	}
 	return m.checkoutErr
+}
+
+func (m *Repository) GetName() string {
+	m.repoName = "fakeRepoName"
+	return m.repoName
+}
+
+func (m *Repository) GetCommitID() string {
+	m.commitID = "fakeCommitString"
+	return m.commitID
 }
 
 // CheckoutAndCreate fulfils the git.Repo interface.

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -60,6 +60,15 @@ func (r *Repository) CheckoutAndCreate(branch string) error {
 	return err
 }
 
+func (r *Repository) GetName() string {
+	return r.repoName
+}
+
+func (r *Repository) GetCommitID() string {
+	commitID, _ := r.execGit(r.repoPath(), nil, "rev-parse", "--short", "HEAD")
+	return string(commitID)
+}
+
 func (r *Repository) Walk(base string, cb func(prefix, name string) error) error {
 	repoBase := r.repoPath(base)
 	prefix := filepath.Dir(repoBase) + "/"


### PR DESCRIPTION
For: https://github.com/rhd-gitops-example/services/issues/21
- Generates a random branch name to use if there isn't one specified in the `promote` command

Right now I've got it generating a random name but then this seems to cause a go panic when trying to checkout the branch in `staging` and I can't track down why....
@mnuttall @bigkevmcd any ideas on why this wouldn't be working would be appreciated :)

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x13ccdda]

goroutine 1 [running]:
github.com/rhd-gitops-example/services/pkg/avancement.(*ServiceManager).checkoutSourceRepo(0xc00009f710, 0x7ffeefbff96a, 0x37, 0x14c17df, 0x6, 0x191e008, 0x28, 0x30, 0xc00009f710)
        /Users/megan.wright@ibm.com/go/src/github.com/services/pkg/avancement/service_manager.go:108 +0x1ba
github.com/rhd-gitops-example/services/pkg/avancement.(*ServiceManager).Promote(0xc00009f710, 0x7ffeefbff9dd, 0x9, 0x7ffeefbff96a, 0x37, 0x7ffeefbff9a7, 0x2b, 0xc0000281e0, 0x25, 0x183a9a0, ...)
        /Users/megan.wright@ibm.com/go/src/github.com/services/pkg/avancement/service_manager.go:69 +0x6f
main.promoteAction(0xc00007aa40, 0x9, 0x10)
        /Users/megan.wright@ibm.com/go/src/github.com/services/cmd/services/main.go:134 +0x409
github.com/urfave/cli/v2.(*Command).Run(0xc0000c47e0, 0xc00007a780, 0x0, 0x0)
        /Users/megan.wright@ibm.com/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/command.go:161 +0x4b9
github.com/urfave/cli/v2.(*App).RunContext(0xc000001980, 0x1560900, 0xc000024088, 0xc0000212b0, 0xd, 0xd, 0x0, 0x0)
        /Users/megan.wright@ibm.com/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:302 +0x790
github.com/urfave/cli/v2.(*App).Run(...)
        /Users/megan.wright@ibm.com/go/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:211
main.main()
        /Users/megan.wright@ibm.com/go/src/github.com/services/cmd/services/main.go:105 +0x1da```