### PR TITLE
Update to use generateName in sample

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,19 +2,19 @@
 
 ## Files
 
-auth.yaml: (template) create secrets for github and docker registry and create the service account
-gitconfig: (template) data file for the gitconfig configmap.  The config map is created by `kubectl create configmap promoteconfigmap --from-file=gitconfig`
+- auth.yaml: (template) create secrets for github and docker registry and create the service account
+- gitconfig: (template) data file for the gitconfig configmap.  The config map is created by `kubectl create configmap promoteconfigmap --from-file=gitconfig`
 
-promotesecret.yaml: (template) create an access token secret for the github repository
-resources.yaml: (template) create pipeline resources for github and docker repository
+- promotesecret.yaml: (template) create an access token secret for the github repository
+- resources.yaml: (template) create pipeline resources for github and docker repository
 
-build-task.yaml: create a build push task
-servicepromote.yaml: (template)create a promote from service repo to env repo task
-servicepromotepipeline.yaml: create a pipeline that executes build, push and promote
-servicepromotepipelinerun.yaml: create a pipelinerun that executes the servicepromotepipeline
+- build-task.yaml: create a build push task
+- servicepromote.yaml: (template)create a promote from service repo to env repo task
+- servicepromotepipeline.yaml: create a pipeline that executes build, push and promote
+- servicepromotepipelinerun.yaml: create a pipelinerun that executes the servicepromotepipeline
 
-promote.yaml: (template)create a promote from one env repo to another env repo task
-promoterun.yaml: create a taskrun that execute promote task
+- promote.yaml: (template)create a promote from one env repo to another env repo task
+- promoterun.yaml: create a taskrun that execute promote task
 
 ## Build docker image with `service promote` command
 
@@ -28,9 +28,9 @@ promoterun.yaml: create a taskrun that execute promote task
 
 - edit all yaml files marked as (template) and gitconfig file.  `<xxx>` must be replaced with the real value
 - create a new namespace e.g. `kubectl create ns promote`
-- apply auth.yaml, promotesecret.yaml, resources.yaml, build-task.yaml, servicepromote.yaml and servicepromotepipelinerun.yaml in the namespace e.g. `kubectl -n <namespace> apply -f <yaml file name>
+- apply auth.yaml, promotesecret.yaml, resources.yaml, build-task.yaml, servicepromote.yaml and servicepromotepipeline.yaml in the namespace e.g. `kubectl apply -n <namespace> -f <yaml file name>`
 - create a configmap by `kubectl create configmap promoteconfigmap --from-file=gitconfig -n <namespace>`
 
 ## Execute pipeline
 
-- create the servicepromotepipelinerun by applying servicepromotepipelinerun.yaml e.g. `apply -n <namespace> apply -f servicepromotepipelinerun.yaml`
+- create the servicepromotepipelinerun using the servicepromotepipelinerun.yaml e.g. `kubectl create -n <namespace> -f servicepromotepipelinerun.yaml`

--- a/docs/promoterun.yaml
+++ b/docs/promoterun.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
-  name: promoterun
+  generateName: promoterun-
 spec:
   params:
   - name: github-secret

--- a/docs/servicepromotepipelinerun.yaml
+++ b/docs/servicepromotepipelinerun.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: service-promote-pipelinerun
+  generateName: service-promote-pipelinerun-
 spec:
   resources:
   - name: git-source


### PR DESCRIPTION
Changed TaskRun and PipelineRun to use generateName in their metadata and the instructions to use `kubectl create` as `apply` does not support generateName

Resolves enabling multiple runs without deleting previous pipelinerun/taskrun :- https://github.com/rhd-gitops-example/services/issues/38