### PR TITLE
Set debug flag when initialising git repo

### DIFF
--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -32,7 +32,7 @@ func NewRepository(repoURL, localPath string, debug bool) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Repository{LocalPath: localPath, RepoURL: repoURL, repoName: name, logger: log.Printf}, nil
+	return &Repository{LocalPath: localPath, RepoURL: repoURL, repoName: name, logger: log.Printf, debug: debug}, nil
 }
 
 func (g *Repository) repoPath(extras ...string) string {

--- a/pkg/git/repository_test.go
+++ b/pkg/git/repository_test.go
@@ -253,6 +253,16 @@ func TestPush(t *testing.T) {
 	assertNoError(t, err)
 }
 
+func TestDebugEnabled(t *testing.T) {
+	tempDir, cleanup := makeTempDir(t)
+	defer cleanup()
+	r, err := NewRepository(testRepository, path.Join(tempDir, "path"), true)
+	assertNoError(t, err)
+	if !r.debug {
+	  t.Fatalf("Debug not set to true")
+	}
+}
+
 func cloneTestRepository(t *testing.T) (*Repository, func()) {
 	tempDir, cleanup := makeTempDir(t)
 	r, err := NewRepository(authenticatedURL(t), tempDir, false)


### PR DESCRIPTION
For: https://github.com/rhd-gitops-example/services/issues/46
Very simple fix - we weren't setting the `debug` parameter of newly created repositories, all works fine now :)

```
(base) Megans-MacBook-Pro:services megan.wright@ibm.com$ ./services promote --debug  --from https://github.com/Megan-Wright/gitops-repo-testing.git --to https://github.com/Megan-Wright/staging.git --service service-a --branch-name megan-test-6****@@@@@ 
2020/04/08 16:23:43 Cloning into 'gitops-repo-testing'...

2020/04/08 16:23:44 Cloning into 'staging'...

2020/04/08 16:23:44 DEBUG: fatal: 'megan-test-6****@@@@@' is not a valid branch name.

2020/04/08 16:23:44 failed to checkout repo: failed to checkout branch megan-test-6****@@@@@ in repo https://github.com/Megan-Wright/staging.git: exit status 128
```