### PR TITLE
Enhance the commit msg and provide ability for user to specify

### DIFF
--- a/cmd/services/main.go
+++ b/cmd/services/main.go
@@ -21,6 +21,7 @@ const (
 	toFlag          = "to"
 	serviceFlag     = "service"
 	cacheDirFlag    = "cache-dir"
+	msgFlag         = "commit-message"
 	nameFlag        = "commit-name"
 	emailFlag       = "commit-email"
 	debugFlag       = "debug"
@@ -77,6 +78,12 @@ var (
 			Required: false,
 			EnvVars:  []string{"COMMIT_EMAIL"},
 		},
+		&cli.StringFlag{
+			Name:     msgFlag,
+			Usage:    "the msg to use on the resultant commit and pull request",
+			Required: false,
+			EnvVars:  []string{"COMMIT_MSG"},
+		},
 		&cli.BoolFlag{
 			Name:     debugFlag,
 			Usage:    "additional debug logging output",
@@ -121,6 +128,7 @@ func promoteAction(c *cli.Context) error {
 	newBranchName := c.String(branchNameFlag)
 	debug := c.Bool(debugFlag)
 	keepCache := c.Bool(keepCacheFlag)
+	msg := c.String(msgFlag)
 
 	cacheDir, err := homedir.Expand(c.String(cacheDirFlag))
 	if err != nil {
@@ -131,7 +139,7 @@ func promoteAction(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return avancement.New(cacheDir, author, avancement.WithDebug(debug)).Promote(service, fromRepo, toRepo, newBranchName, keepCache)
+	return avancement.New(cacheDir, author, avancement.WithDebug(debug)).Promote(service, fromRepo, toRepo, newBranchName, msg, keepCache)
 }
 
 func newAuthor(c *cli.Context) (*git.Author, error) {

--- a/pkg/avancement/pull_request.go
+++ b/pkg/avancement/pull_request.go
@@ -10,20 +10,28 @@ import (
 // TODO: OptionFuncs for Base and Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
-func makePullRequestInput(fromURL, toURL, branchName string) (*scm.PullRequestInput, error) {
-	_, fromRepo, err := util.ExtractUserAndRepo(fromURL)
-	if err != nil {
-		return nil, err
-	}
+func makePullRequestInput(fromLocal bool, fromURL, toURL, branchName, prBody string) (*scm.PullRequestInput, error) {
+	var title string
+
 	fromUser, toRepo, err := util.ExtractUserAndRepo(toURL)
 	if err != nil {
 		return nil, err
 	}
-	title := fmt.Sprintf("promotion from %s to %s", fromRepo, toRepo)
+
+	if fromLocal {
+		title = fmt.Sprintf("promotion from local filesystem directory to %s", toRepo)
+	} else {
+		_, fromRepo, err := util.ExtractUserAndRepo(fromURL)
+		if err != nil {
+			return nil, err
+		}
+		title = fmt.Sprintf("promotion from %s to %s", fromRepo, toRepo)
+	}
+
 	return &scm.PullRequestInput{
 		Title: title,
 		Head:  fmt.Sprintf("%s:%s", fromUser, branchName),
 		Base:  "master",
-		Body:  "this is a test body",
+		Body:  prBody,
 	}, nil
 }

--- a/pkg/avancement/pull_request_test.go
+++ b/pkg/avancement/pull_request_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMakePullRequestInput(t *testing.T) {
-	pr, err := makePullRequestInput("https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "my-test-branch")
+	pr, err := makePullRequestInput(false, "https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "my-test-branch", "foo bar wibble")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,7 +18,7 @@ func TestMakePullRequestInput(t *testing.T) {
 		Title: "promotion from dev-env to prod-env",
 		Head:  "project:my-test-branch",
 		Base:  "master",
-		Body:  "this is a test body",
+		Body:  "foo bar wibble",
 	}
 
 	if diff := cmp.Diff(want, pr); diff != "" {

--- a/pkg/git/mock/mock.go
+++ b/pkg/git/mock/mock.go
@@ -186,7 +186,7 @@ func (m *Repository) AssertFileCopiedInBranch(t *testing.T, branch, from, name s
 // message and auth token.
 func (m *Repository) AssertCommit(t *testing.T, branch, msg string, a *git.Author) {
 	if !hasString(key(branch, msg, a.Token), m.commits) {
-		t.Fatalf("no matching commit %#v in branch %s using token %s", msg, branch, a.Token)
+		t.Fatalf("no matching commit %#v in branch %s using token %s.  Commits available: %+v", msg, branch, a.Token, m.commits)
 	}
 }
 


### PR DESCRIPTION
Add ability to specify the commit message using `--commit-message "some message text"` (and use this message in the PR details), also enhances the default message.