### PR TITLE
generateBranchForLocalSource fix

### DIFF
--- a/pkg/avancement/service_manager_test.go
+++ b/pkg/avancement/service_manager_test.go
@@ -203,12 +203,26 @@ func TestGenerateBranchWithSuccess(t *testing.T) {
 	GenerateBranchWithSuccess(t, repo)
 }
 
+func TestGenerateBranchForLocalSource(t *testing.T) {
+	source := NewLocal("/path/to/topLevel")
+	GenerateBranchForLocalWithSuccess(t, source)
+}
+
 func GenerateBranchWithSuccess(t *testing.T, repo git.Repo) {
 	branch := generateBranch(repo)
 	nameRegEx := "^([0-9A-Za-z]+)-([0-9a-z]{7})-([0-9A-Za-z]{5})$"
 	_, err := regexp.Match(nameRegEx, []byte(branch))
 	if err != nil {
 		t.Fatalf("failed to generate a branch name matching pattern %s", nameRegEx)
+	}
+}
+
+func GenerateBranchForLocalWithSuccess(t *testing.T, source git.Source) {
+	branch := generateBranchForLocalSource(source)
+	nameRegEx := "^path-to-topLevel-local-dir-([0-9A-Za-z]{5})$"
+	_, err := regexp.Match(nameRegEx, []byte(branch))
+	if err != nil {
+		t.Fatalf("generated name `%s` for local case %s failed to matching pattern %s", nameRegEx, source.GetName(), nameRegEx)
 	}
 }
 
@@ -246,6 +260,10 @@ func (s *mockSource) Walk(_ string, cb func(string, string) error) error {
 		}
 	}
 	return nil
+}
+
+func (s *mockSource) GetName() string {
+	return "mock-source-name"
 }
 
 func (s *mockSource) AddFiles(name string) {

--- a/pkg/avancement/service_manager_test.go
+++ b/pkg/avancement/service_manager_test.go
@@ -200,15 +200,15 @@ func TestPromoteWithCacheDeletionFailure(t *testing.T) {
 
 func TestGenerateBranchWithSuccess(t *testing.T) {
 	repo := mock.New("/dev", "master")
-	GenerateBranchWithSuccess(t, repo)
+	generateBranchWithSuccess(t, repo)
 }
 
 func TestGenerateBranchForLocalSource(t *testing.T) {
 	source := NewLocal("/path/to/topLevel")
-	GenerateBranchForLocalWithSuccess(t, source)
+	generateBranchForLocalWithSuccess(t, source)
 }
 
-func GenerateBranchWithSuccess(t *testing.T, repo git.Repo) {
+func generateBranchWithSuccess(t *testing.T, repo git.Repo) {
 	branch := generateBranch(repo)
 	nameRegEx := "^([0-9A-Za-z]+)-([0-9a-z]{7})-([0-9A-Za-z]{5})$"
 	_, err := regexp.Match(nameRegEx, []byte(branch))
@@ -217,7 +217,7 @@ func GenerateBranchWithSuccess(t *testing.T, repo git.Repo) {
 	}
 }
 
-func GenerateBranchForLocalWithSuccess(t *testing.T, source git.Source) {
+func generateBranchForLocalWithSuccess(t *testing.T, source git.Source) {
 	branch := generateBranchForLocalSource(source)
 	nameRegEx := "^path-to-topLevel-local-dir-([0-9A-Za-z]{5})$"
 	_, err := regexp.Match(nameRegEx, []byte(branch))

--- a/pkg/git/copy_test.go
+++ b/pkg/git/copy_test.go
@@ -129,6 +129,10 @@ func (s *mockSource) Walk(base string, cb func(string, string) error) error {
 	return nil
 }
 
+func (s *mockSource) GetName() string {
+	return "local-dir-repo-name-unknown"
+}
+
 func (s *mockSource) addFile(name string) {
 	if s.files == nil {
 		s.files = []string{}

--- a/pkg/git/interface.go
+++ b/pkg/git/interface.go
@@ -15,16 +15,16 @@ type Source interface {
 	// Walk walks the repository tree, calling the callback with the prefix and
 	// filename.
 	Walk(path string, cb func(prefix, name string) error) error
+	GetName() string
 }
 
 type Repo interface {
 	Destination
 	Source
-	GetName() string
-	GetCommitID() string
 	Clone() error
 	Checkout(branch string) error
 	CheckoutAndCreate(branch string) error
+	GetCommitID() string
 	StageFiles(filenames ...string) error
 	Commit(msg string, author *Author) error
 	Push(branch string) error

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -54,3 +54,10 @@ func (l *Local) Walk(_ string, cb func(prefix, name string) error) error {
 		return cb(prefix, strings.TrimPrefix(path, prefix))
 	})
 }
+
+// GetName - we're using a directory that may not be a git repo, all we know is our path
+func (l *Local) GetName() string {
+	path := filepath.ToSlash(l.LocalPath)
+	name := strings.ReplaceAll(path, "/", "-")
+	return name
+}

--- a/pkg/local/local_test.go
+++ b/pkg/local/local_test.go
@@ -63,6 +63,10 @@ func (s *mockSource) Walk(_ string, cb func(string, string) error) error {
 	return nil
 }
 
+func (s *mockSource) GetName() string {
+	return "AlwaysTheSameName"
+}
+
 func (s *mockSource) addFile(name string) {
 	if s.files == nil {
 		s.files = []string{}


### PR DESCRIPTION
Fix a panic in service_manager.Promote() when handling local file systems. We need to generate branch names for target pull requests differently when we can't be sure we are working with a Git repository for the source. 