### PR TITLE
Strip leading - from local branch names

### DIFF
--- a/pkg/avancement/service_manager_test.go
+++ b/pkg/avancement/service_manager_test.go
@@ -211,18 +211,24 @@ func TestGenerateBranchForLocalSource(t *testing.T) {
 func generateBranchWithSuccess(t *testing.T, repo git.Repo) {
 	branch := generateBranch(repo)
 	nameRegEx := "^([0-9A-Za-z]+)-([0-9a-z]{7})-([0-9A-Za-z]{5})$"
-	_, err := regexp.Match(nameRegEx, []byte(branch))
+	matched, err := regexp.Match(nameRegEx, []byte(branch))
 	if err != nil {
-		t.Fatalf("failed to generate a branch name matching pattern %s", nameRegEx)
+		t.Fatalf("Regexp err %s in generateBranchWithSuccess matching pattern %s to %s", err, nameRegEx, branch)
+	}
+	if !matched {
+		t.Fatalf("generated name `%s` failed to match pattern %s", branch, nameRegEx)
 	}
 }
 
 func generateBranchForLocalWithSuccess(t *testing.T, source git.Source) {
 	branch := generateBranchForLocalSource(source)
 	nameRegEx := "^path-to-topLevel-local-dir-([0-9A-Za-z]{5})$"
-	_, err := regexp.Match(nameRegEx, []byte(branch))
+	matched, err := regexp.Match(nameRegEx, []byte(branch))
 	if err != nil {
-		t.Fatalf("generated name `%s` for local case %s failed to matching pattern %s", nameRegEx, source.GetName(), nameRegEx)
+		t.Fatalf("Regexp err %s in generateBranchForLocalWithSuccess matching pattern %s to %s", err, nameRegEx, branch)
+	}
+	if !matched {
+		t.Fatalf("generated name `%s` for local case %s failed to matching pattern %s", branch, source.GetName(), nameRegEx)
 	}
 }
 
@@ -263,7 +269,10 @@ func (s *mockSource) Walk(_ string, cb func(string, string) error) error {
 }
 
 func (s *mockSource) GetName() string {
-	return "mock-source-name"
+	path := filepath.ToSlash(s.localPath)
+	path = strings.TrimLeft(path, "/")
+	name := strings.ReplaceAll(path, "/", "-")
+	return name
 }
 
 func (s *mockSource) AddFiles(name string) {

--- a/pkg/git/mock/mock.go
+++ b/pkg/git/mock/mock.go
@@ -60,7 +60,7 @@ func (m *Repository) GetName() string {
 }
 
 func (m *Repository) GetCommitID() string {
-	m.commitID = "fakeCommitString"
+	m.commitID = "a1b2c3d"
 	return m.commitID
 }
 

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -58,6 +58,7 @@ func (l *Local) Walk(_ string, cb func(prefix, name string) error) error {
 // GetName - we're using a directory that may not be a git repo, all we know is our path
 func (l *Local) GetName() string {
 	path := filepath.ToSlash(l.LocalPath)
+	path = strings.TrimLeft(path, "/")
 	name := strings.ReplaceAll(path, "/", "-")
 	return name
 }

--- a/pkg/local/local_test.go
+++ b/pkg/local/local_test.go
@@ -64,7 +64,7 @@ func (s *mockSource) Walk(_ string, cb func(string, string) error) error {
 }
 
 func (s *mockSource) GetName() string {
-	return "AlwaysTheSameName"
+	return "/workspace/path/to/dir"
 }
 
 func (s *mockSource) addFile(name string) {


### PR DESCRIPTION
We were turning the leading / of a path name into a - which resulted in invalid branch names in the local case. 