### PR TITLE
Gitlab, GHE support

### DIFF
--- a/pkg/avancement/pull_request.go
+++ b/pkg/avancement/pull_request.go
@@ -13,7 +13,7 @@ import (
 func makePullRequestInput(fromLocal bool, fromURL, toURL, branchName, prBody string) (*scm.PullRequestInput, error) {
 	var title string
 
-	fromUser, toRepo, err := util.ExtractUserAndRepo(toURL)
+	_, toRepo, err := util.ExtractUserAndRepo(toURL)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func makePullRequestInput(fromLocal bool, fromURL, toURL, branchName, prBody str
 
 	return &scm.PullRequestInput{
 		Title: title,
-		Head:  fmt.Sprintf("%s:%s", fromUser, branchName),
+		Head:  branchName,
 		Base:  "master",
 		Body:  prBody,
 	}, nil

--- a/pkg/avancement/pull_request_test.go
+++ b/pkg/avancement/pull_request_test.go
@@ -16,7 +16,7 @@ func TestMakePullRequestInput(t *testing.T) {
 
 	want := &scm.PullRequestInput{
 		Title: "promotion from dev-env to prod-env",
-		Head:  "project:my-test-branch",
+		Head:  "my-test-branch",
 		Base:  "master",
 		Body:  "foo bar wibble",
 	}

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -72,12 +72,26 @@ func makePromoteCmd() *cobra.Command {
 	)
 	logIfError(viper.BindPFlag(msgFlag, cmd.Flags().Lookup(msgFlag)))
 
+	cmd.Flags().String(
+		repoTypeFlag,
+		"github",
+		"the type of repository: github, gitlab or ghe",
+	)
+	logIfError(viper.BindPFlag(repoTypeFlag, cmd.Flags().Lookup(repoTypeFlag)))
+
 	cmd.Flags().Bool(
 		debugFlag,
 		false,
 		"additional debug logging output",
 	)
 	logIfError(viper.BindPFlag(debugFlag, cmd.Flags().Lookup(debugFlag)))
+
+	cmd.Flags().Bool(
+		insecureSkipVerifyFlag,
+		false,
+		"Insecure skip verify TLS certificate",
+	)
+	logIfError(viper.BindPFlag(insecureSkipVerifyFlag, cmd.Flags().Lookup(insecureSkipVerifyFlag)))
 
 	cmd.Flags().Bool(
 		keepCacheFlag,
@@ -98,7 +112,9 @@ func promoteAction(c *cobra.Command, args []string) error {
 	fromRepo := viper.GetString(fromFlag)
 	toRepo := viper.GetString(toFlag)
 	service := viper.GetString(serviceFlag)
+	repoType := viper.GetString(repoTypeFlag)
 	newBranchName := viper.GetString(branchNameFlag)
+	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
 	debug := viper.GetBool(debugFlag)
 	keepCache := viper.GetBool(keepCacheFlag)
 	msg := viper.GetString(msgFlag)
@@ -112,7 +128,7 @@ func promoteAction(c *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return avancement.New(cacheDir, author, avancement.WithDebug(debug)).Promote(service, fromRepo, toRepo, newBranchName, msg, keepCache)
+	return avancement.New(cacheDir, author, avancement.WithDebug(debug), avancement.WithInsecureSkipVerify(insecureSkipVerify), avancement.WithRepoType(repoType)).Promote(service, fromRepo, toRepo, newBranchName, msg, keepCache)
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -10,17 +10,19 @@ import (
 )
 
 const (
-	githubTokenFlag = "github-token"
-	branchNameFlag  = "branch-name"
-	fromFlag        = "from"
-	toFlag          = "to"
-	serviceFlag     = "service"
-	cacheDirFlag    = "cache-dir"
-	msgFlag         = "commit-message"
-	nameFlag        = "commit-name"
-	emailFlag       = "commit-email"
-	debugFlag       = "debug"
-	keepCacheFlag   = "keep-cache"
+	githubTokenFlag        = "github-token"
+	branchNameFlag         = "branch-name"
+	fromFlag               = "from"
+	toFlag                 = "to"
+	serviceFlag            = "service"
+	repoTypeFlag           = "repository-type"
+	cacheDirFlag           = "cache-dir"
+	msgFlag                = "commit-message"
+	nameFlag               = "commit-name"
+	emailFlag              = "commit-email"
+	insecureSkipVerifyFlag = "insecure-skip-verify"
+	debugFlag              = "debug"
+	keepCacheFlag          = "keep-cache"
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -2,20 +2,46 @@ package git
 
 import (
 	"context"
-
+	"net/http"
+	"net/url"
+	"crypto/tls"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/github"
+	"github.com/jenkins-x/go-scm/scm/driver/gitlab"
 	"golang.org/x/oauth2"
 )
 
-// CreateGitHubClient creates and returns a go-scm GitHub client, using the provided
+// CreateClient creates and returns a go-scm GitHub client, using the provided
 // oauth2 token.
-// TODO: This should probably use https://github.com/jenkins-x/go-scm/tree/master/scm/factory
-func CreateGitHubClient(token string) *scm.Client {
-	client := github.NewDefault()
+func CreateClient(token, toURL, repoType  string, tlsVerify bool) *scm.Client {
+	var client *scm.Client
+	u, _ := url.Parse(toURL)
+	if repoType == "gitlab" {
+		client = gitlab.NewDefault()
+	} else if repoType == "ghe" {
+		client, _ = github.New(u.Scheme + "://" + u.Host + "/api/v3")
+	} else {
+		client = github.NewDefault()
+	}
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
-	client.Client = oauth2.NewClient(context.Background(), ts)
+	if tlsVerify {
+		client.Client = oauth2.NewClient(context.Background(), ts)
+	} else {
+		client.Client = &http.Client{
+			Transport: &oauth2.Transport{
+				Source: ts,
+				Base: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
+			},
+		}
+	}
+	if repoType == "gitlab" {
+		u, _ := url.Parse(toURL)
+		client.BaseURL.Host = u.Host
+	}
 	return client
 }
+

--- a/pkg/git/client_test.go
+++ b/pkg/git/client_test.go
@@ -1,0 +1,24 @@
+package git
+
+import (
+	"testing"
+)
+func TestCreateClient(t *testing.T) {
+	create := []struct {
+		toUrl       string
+		repoType  string
+		wantHost  string
+	}{
+		{"https://github.com/myorg/myrepo.git", "github", "api.github.com"},
+		{"https://gitlab.local.com/myorg/subdir/myrepo.git", "gitlab", "gitlab.local.com"},
+		{"https://github.local.com/myorg/myrepo.git", "ghe", "github.local.com"},
+	}
+
+	for _, tt := range create {
+		client := CreateClient("tokendata", tt.toUrl, tt.repoType, true)
+		if tt.wantHost != client.BaseURL.Host {
+			t.Errorf("CreateClient(%s) got host %s, want %s", tt.toUrl, client.BaseURL.Host, tt.wantHost)
+			continue
+		}
+	}
+}

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -20,6 +20,7 @@ type Repository struct {
 	LocalPath string
 	RepoURL   string
 	repoName  string
+	tlsVerify bool
 	debug     bool
 	logger    func(fmt string, v ...interface{})
 }
@@ -28,12 +29,12 @@ type Repository struct {
 //
 // The repoURL should be of the form https://github.com/myorg/myrepo.
 // The path should be a local directory where the contents are cloned to.
-func NewRepository(repoURL, localPath string, debug bool) (*Repository, error) {
+func NewRepository(repoURL, localPath string, tlsVerify bool, debug bool) (*Repository, error) {
 	name, err := repoName(repoURL)
 	if err != nil {
 		return nil, err
 	}
-	return &Repository{LocalPath: localPath, RepoURL: repoURL, repoName: name, logger: log.Printf, debug: debug}, nil
+	return &Repository{LocalPath: localPath, RepoURL: repoURL, repoName: name, tlsVerify: tlsVerify, logger: log.Printf, debug: debug}, nil
 }
 
 func (g *Repository) repoPath(extras ...string) string {
@@ -124,6 +125,9 @@ func (r *Repository) Push(branchName string) error {
 
 func (r *Repository) execGit(workingDir string, env []string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
+	if !r.tlsVerify {
+		env = append(env, "GIT_SSL_NO_VERIFY=true")
+	}
 	if env != nil {
 		cmd.Env = append(os.Environ(), env...)
 	}

--- a/pkg/git/repository_test.go
+++ b/pkg/git/repository_test.go
@@ -44,7 +44,7 @@ func TestRepoName(t *testing.T) {
 func TestCloneCreatesDirectory(t *testing.T) {
 	tempDir, cleanup := makeTempDir(t)
 	defer cleanup()
-	r, err := NewRepository(testRepository, path.Join(tempDir, "path"), false)
+	r, err := NewRepository(testRepository, path.Join(tempDir, "path"), true, false)
 	assertNoError(t, err)
 	err = r.Clone()
 	assertNoError(t, err)
@@ -256,7 +256,7 @@ func TestPush(t *testing.T) {
 func TestDebugEnabled(t *testing.T) {
 	tempDir, cleanup := makeTempDir(t)
 	defer cleanup()
-	r, err := NewRepository(testRepository, path.Join(tempDir, "path"), true)
+	r, err := NewRepository(testRepository, path.Join(tempDir, "path"), false, true)
 	assertNoError(t, err)
 	if !r.debug {
 		t.Fatalf("Debug not set to true")
@@ -265,7 +265,7 @@ func TestDebugEnabled(t *testing.T) {
 
 func cloneTestRepository(t *testing.T) (*Repository, func()) {
 	tempDir, cleanup := makeTempDir(t)
-	r, err := NewRepository(authenticatedURL(t), tempDir, false)
+	r, err := NewRepository(authenticatedURL(t), tempDir, false, false)
 	assertNoError(t, err)
 	err = r.Clone()
 	assertNoError(t, err)


### PR DESCRIPTION
This PR implements https://github.com/rhd-gitops-example/services/issues/60 and https://github.com/rhd-gitops-example/services/issues/59.

New flags are added:
1. insecure-skip-verification: true or false (default is false)
2. repository-type: github, gitlab or ghe (default is github)