### PR TITLE
Handle to/from URLs without .git suffix

### DIFF
--- a/pkg/avancement/service_manager.go
+++ b/pkg/avancement/service_manager.go
@@ -252,14 +252,8 @@ func createPullRequest(ctx context.Context, fromURL, toURL, newBranchName, commi
 
 	u, _ := url.Parse(toURL)
 	// take out ".git" at the end only if present
-	pathToUse := ""
-	// We take from index 1 as index 0 is a slash
-	lastFourChars := u.Path[len(u.Path)-4:]
-	if lastFourChars == ".git" {
-		pathToUse = u.Path[1 : len(u.Path)-4]
-	} else {
-		pathToUse = u.Path[1:]
-	}
+	// 1: is important so we don't have a leading slash
+	pathToUse := strings.TrimSuffix(u.Path, ".git")[1:]
 	pr, _, err := client.PullRequests.Create(ctx, pathToUse, prInput)
 	return pr, err
 }

--- a/pkg/avancement/service_manager.go
+++ b/pkg/avancement/service_manager.go
@@ -251,8 +251,16 @@ func createPullRequest(ctx context.Context, fromURL, toURL, newBranchName, commi
 	}
 
 	u, _ := url.Parse(toURL)
-	// take out ".git" at the end
-	pr, _, err := client.PullRequests.Create(ctx, u.Path[1:len(u.Path)-4], prInput)
+	// take out ".git" at the end only if present
+	pathToUse := ""
+	// We take from index 1 as index 0 is a slash
+	lastFourChars := u.Path[len(u.Path)-4:]
+	if lastFourChars == ".git" {
+		pathToUse = u.Path[1 : len(u.Path)-4]
+	} else {
+		pathToUse = u.Path[1:]
+	}
+	pr, _, err := client.PullRequests.Create(ctx, pathToUse, prInput)
 	return pr, err
 }
 

--- a/pkg/avancement/service_manager.go
+++ b/pkg/avancement/service_manager.go
@@ -251,9 +251,7 @@ func createPullRequest(ctx context.Context, fromURL, toURL, newBranchName, commi
 	}
 
 	u, _ := url.Parse(toURL)
-	// take out ".git" at the end only if present
-	// 1: is important so we don't have a leading slash
-	pathToUse := strings.TrimSuffix(u.Path, ".git")[1:]
+	pathToUse := strings.TrimPrefix(strings.TrimSuffix(u.Path, ".git"), "/")
 	pr, _, err := client.PullRequests.Create(ctx, pathToUse, prInput)
 	return pr, err
 }


### PR DESCRIPTION
This is to prevent the path being mangled (if it didn't have .git, the path to use would no longer be correct), so users can use --from or --to without .git on the end now

Closes https://github.com/rhd-gitops-example/services/issues/81

A test would be helpful but we don't have any test coverage that directly hits createPullRequest so open to suggestions