### PR TITLE
Add an example how to run services as an oc plugin, fix for user.Name and user.Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ $ export GITHUB_TOKEN=<paste in GitHub access token>
 $ ./services promote --from https://github.com/organisation/first-environment.git --to https://github.com/organisation/second-environment.git --service service-a --commit-name <User to commit as> --commit-email <Email to commit as>
 ```
 
-If the `commit-name` and `commit-email` are not provided, it will attempt to find them in `~/.gitconfig`, otherwise it will fail.
-
-
 This will _copy_ all files under `/services/service-a/base/config/*` in `first-environment` to `second-environment`, commit and push, and open a PR for the change.
 
 

--- a/README.md
+++ b/README.md
@@ -87,3 +87,13 @@ See the [tekton-example](./tekton-example/README.md) directory for more on using
 ## Release process
 
 When a new tag is pushed with the `v` prefix, a GitHub release will be created with binaries produced for 64-bit Linux, and Mac automatically.
+
+## Experimental plugin section
+
+Inside of the `plugin` folder you'll see documentation and other files related to using the `services` binary as a plugin to `oc`. This has been tested with the following version on OpenShift 4.3:
+
+```
+Client Version: openshift-clients-4.3.13-202004121622
+Server Version: 4.3.13
+Kubernetes Version: v1.16.2
+```

--- a/automerge-example/README.md
+++ b/automerge-example/README.md
@@ -18,13 +18,6 @@ This example is for more advanced users. Start with the [tekton-example](../tekt
 
 Our samples currently work with GitHub. They use the `hub` CLI to create a merge commit that when pushed, will merge the associated Pull Request. See [here](https://hub.github.com/hub-merge.1.html) for more details.
 
-## gitconfig
-
-Since we are creating git commits within the Tekton tasks, we need to know the username and email address to associate with them, as in our ['tekton-example'](../tekton-example/README.md). So, edit `gitconfig` and
-
-```sh
-kubectl create configmap promoteconfigmap --from-file=gitconfig
-```
 
 ## Dockerfile
 
@@ -84,7 +77,7 @@ Set up your Service Account and Secret as per the guide above. In this case you 
 - A ServiceAccount configured for use by Tekton.
 - A Tekton-compatible Secret patched onto that that ServiceAccount containing your GitHub token.
 
-This secret is used in two related ways. We check the source repository out using a Tekton Git PipelineResource. This sets up `~/.gitconfig` with the credentials needed for `git push` to work. It gets these credentials from the `accessToken` field of the relevant secret patched onto the ServiceAccount running the Tekton Task. We then extract the same field and export it into the `GITHUB_TOKEN` environment variable to make `hub merge` work. Instructions for creating this secret are in the Getting Started document linked above. You should have resources of the form, 
+This secret is used in two related ways. We check the source repository out using a Tekton Git PipelineResource. This sets up Git with the credentials needed for `git push` to work. It gets these credentials from the `accessToken` field of the relevant secret patched onto the ServiceAccount running the Tekton Task. We then extract the same field and export it into the `GITHUB_TOKEN` environment variable to make `hub merge` work. Instructions for creating this secret are in the Getting Started document linked above. You should have resources of the form, 
 
 ```yaml
 ---

--- a/automerge-example/standalone/templates/automerge-task.yaml
+++ b/automerge-example/standalone/templates/automerge-task.yaml
@@ -4,19 +4,15 @@ metadata:
   name: automerge-task
 spec:
   params:
-  - name: github-config
+  - name: commit-name
     type: string
-    description: configmap name of the gitconfig file that has user name, user e-mail.  The key name is gitconfig. It can be created by "kubectl create configmap <configmap name> --from-file=gitconfig"
+    description: GitHub name to author the commit with
+  - name: commit-email
+    type: string
+    description: GitHub email to author the commit with
   - name: github-secret
     type: string
     description: Name of the secret containing an access token for Github. Expects Tekton format, 'username' and 'password' keys.
-  volumes:
-  - name: gitconfig
-    configMap:
-      name: $(params.github-config)
-      items:
-        - key: gitconfig
-          path: gitconfig
   inputs:
     resources:
       - name: git-source
@@ -31,13 +27,8 @@ spec:
       kubectl apply -k git-source/env --dry-run=client
   - name: merge-pr
     image: YOUR_DOCKER_HUB_ID/hub-test
-    volumeMounts:
-    - name: gitconfig
-      mountPath: /root
     script: |
       #!/bin/bash -x
-
-      cat /root/gitconfig >> $HOME/.gitconfig
       fullPRLink=$(yq r pull-request/pr.json 'Link')
       prURL=${fullPRLink%.diff}
 

--- a/automerge-example/webhooks/templates/automerge-task.yaml
+++ b/automerge-example/webhooks/templates/automerge-task.yaml
@@ -4,10 +4,7 @@ metadata:
   name: automerge-task
 spec:
   params:
-  - name: github-config
-    type: string
-    description: configmap name of the gitconfig file that has user name, user e-mail.  The key name is gitconfig. It can be created by "kubectl create configmap <configmap name> --from-file=gitconfig"
-  - name: github-secret
+ - name: github-secret
     type: string
     description: Name of the secret containing an access token for Github. Expects Tekton format, 'username' and 'password' keys.
   - name: event-type
@@ -19,13 +16,6 @@ spec:
   - name: pull-request-url
     type: string
     description: The URL of the pull request, where applicable
-  volumes:
-  - name: gitconfig
-    configMap:
-      name: $(params.github-config)
-      items:
-        - key: gitconfig
-          path: gitconfig
   inputs:
     resources:
       - name: git-source
@@ -38,9 +28,6 @@ spec:
       kubectl apply -k git-source/env --dry-run=client
   - name: merge-pr
     image: YOUR_DOCKER_HUB_ID/hub-test
-    volumeMounts:
-    - name: gitconfig
-      mountPath: /root
     script: |
       #!/bin/bash -x
 
@@ -52,12 +39,11 @@ spec:
           echo "do nothing"
         fi
       elif [ $(params.event-type) = "pull_request" ]; then
-      
-        cat /root/gitconfig >> $HOME/.gitconfig
         # GHE requires some extra config
         # Replace `YOUR_GHE` with your GitHub Enterprise domain e.g. `github.ibm.com`
         git config --global --add hub.host YOUR_GHE
-
+        git config --global user.name $(params.commit-name)
+        git config --global user.email $(params.commit-email)
         cd git-source
         export HUB_VERBOSE=true
         hub merge $(params.pull-request-url)

--- a/pkg/git/mock/mock.go
+++ b/pkg/git/mock/mock.go
@@ -203,7 +203,6 @@ func (m *Repository) AssertBranchNotCreated(t *testing.T, from, name string) {
 // AssertFileCopiedInBranch asserts the filename was copied from and to in a
 // branch.
 func (m *Repository) AssertFileCopiedInBranch(t *testing.T, branch, from, name string) {
-	fmt.Printf("copied: %s\n", m.copiedFiles)
 	if !hasString(key(branch, from, name), m.copiedFiles) {
 		t.Fatalf("file %s was not copied from %s to branch %s", name, from, branch)
 	}

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -159,14 +159,16 @@ func (r *Repository) StageFiles(filenames ...string) error {
 
 // Commit does the git commit -m with the msg & author
 // after first running git config commands for the user.name and user.email
+// these are intentionally *not* global settings because we don't want to touch a user's $HOME/.gitconfig
+// This means the settings only apply inside of our local repository cache.
 func (r *Repository) Commit(msg string, author *Author) error {
-	command := fmt.Sprintf("config --global user.name \"%s\"", author.Name)
+	command := fmt.Sprintf("config user.name \"%s\"", author.Name)
 	commandAsArgs := strings.Split(command, " ")
 	_, err := r.execGit(r.repoPath(), envFromAuthor(author), commandAsArgs...)
 	if err != nil {
 		return fmt.Errorf("could not set name, err: %w", err)
 	}
-	command = fmt.Sprintf("config --global user.email \"%s\"", author.Email)
+	command = fmt.Sprintf("config user.email \"%s\"", author.Email)
 	commandAsArgs = strings.Split(command, " ")
 	_, err = r.execGit(r.repoPath(), envFromAuthor(author), commandAsArgs...)
 	if err != nil {

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -162,9 +162,14 @@ func (r *Repository) StageFiles(filenames ...string) error {
 // these are intentionally *not* global settings because we don't want to touch a user's $HOME/.gitconfig
 // This means the settings only apply inside of our local repository cache.
 func (r *Repository) Commit(msg string, author *Author) error {
+	_, err := r.execGit(r.repoPath(), envFromAuthor(author), "status")
+	if err != nil {
+		return fmt.Errorf("could not set name, err: %w", err)
+	}
+
 	command := fmt.Sprintf("config user.name \"%s\"", author.Name)
 	commandAsArgs := strings.Split(command, " ")
-	_, err := r.execGit(r.repoPath(), envFromAuthor(author), commandAsArgs...)
+	_, err = r.execGit(r.repoPath(), envFromAuthor(author), commandAsArgs...)
 	if err != nil {
 		return fmt.Errorf("could not set name, err: %w", err)
 	}

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu AS oc-base
 
 # Install curl
 RUN apt-get update 
@@ -22,4 +22,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 RUN microdnf install git
 WORKDIR /root/
 COPY --from=build /go/build/services /usr/local/bin/oc-services
-ENTRYPOINT ["/usr/local/bin/oc services"]
+COPY --from=oc-base /usr/local/bin/oc /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/oc"]

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,1 +1,28 @@
-TODO this
+FROM ubuntu
+RUN apt-get update
+
+# Install curl
+RUN apt-get update 
+RUN apt-get install -y curl
+
+# Install oc
+RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/macosx/oc.tar.gz
+RUN tar xvf oc.tar.gz
+RUN chmod +x oc/oc
+COPY oc/oc /usr/local/bin
+
+# Build services binary, rename and add to path
+FROM golang:latest AS build
+COPY . /go/build
+WORKDIR /go/build
+
+RUN go build ./cmd/services
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+RUN microdnf install git
+WORKDIR /root/
+COPY --from=build /go/build/services /usr/local/bin/oc-services
+ENTRYPOINT ["/usr/local/bin/oc services"]
+
+
+

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,16 +1,14 @@
 FROM ubuntu
-RUN apt-get update
 
 # Install curl
 RUN apt-get update 
 RUN apt-get install -y curl
 
 # Install oc
-RUN curl -O https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/macosx/oc.tar.gz
+RUN curl -O https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/linux/oc.tar.gz
 
 RUN tar xvf oc.tar.gz
 RUN chmod +x ./oc
-RUN ls -la oc
 RUN cp ./oc /usr/local/bin/
 
 # Build services binary, rename and add to path
@@ -18,13 +16,10 @@ FROM golang:latest AS build
 COPY . /go/build
 WORKDIR /go/build
 
-RUN go build ./cmd/services
+RUN CGO_ENABLED=0 GOOS=linux go build ./cmd/services
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 RUN microdnf install git
 WORKDIR /root/
 COPY --from=build /go/build/services /usr/local/bin/oc-services
 ENTRYPOINT ["/usr/local/bin/oc services"]
-
-
-

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -23,9 +23,4 @@ RUN microdnf install git
 WORKDIR /root/
 COPY --from=build /go/build/services /usr/local/bin/oc-services
 COPY --from=oc-base /usr/local/bin/oc /usr/local/bin/
-# For easy testing - you would docker run -it mydockerusername/oc-services-plugin-experiment:latest
-# and once inside do: 
-# export GITHUB_TOKEN=foo
-# oc services promote --from https://github.com/myorg/myrepo --to https://github.com/myorg/myrepo --service promote-demo --commit-name=myname --commit-email=myemail
-# ENTRYPOINT ["/bin/bash"]
 ENTRYPOINT ["/usr/local/bin/oc"]

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -23,5 +23,9 @@ RUN microdnf install git
 WORKDIR /root/
 COPY --from=build /go/build/services /usr/local/bin/oc-services
 COPY --from=oc-base /usr/local/bin/oc /usr/local/bin/
-
+# For easy testing - you would docker run -it mydockerusername/oc-services-plugin-experiment:latest
+# and once inside do: 
+# export GITHUB_TOKEN=foo
+# oc services promote --from https://github.com/myorg/myrepo --to https://github.com/myorg/myrepo --service promote-demo --commit-name=myname --commit-email=myemail
+# ENTRYPOINT ["/bin/bash"]
 ENTRYPOINT ["/usr/local/bin/oc"]

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -6,10 +6,12 @@ RUN apt-get update
 RUN apt-get install -y curl
 
 # Install oc
-RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/macosx/oc.tar.gz
+RUN curl -O https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/macosx/oc.tar.gz
+
 RUN tar xvf oc.tar.gz
-RUN chmod +x oc/oc
-COPY oc/oc /usr/local/bin
+RUN chmod +x ./oc
+RUN ls -la oc
+RUN cp ./oc /usr/local/bin/
 
 # Build services binary, rename and add to path
 FROM golang:latest AS build

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,0 +1,1 @@
+TODO this

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -8,6 +8,6 @@ Build it with the following command from the main `services` folder:
 
 You can then do
 
-`docker run <dockerusername>/oc-services-plugin-experiment:latest services promote`
+`docker run -e GITHUB_TOKEN=<mytoken> <dockerusername>/oc-services-plugin-experiment:latest services promote`
 
 and that's using `promote` but from being an `oc plugin` - useful for seeing if anything breaks.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 This folder contains an example script that will compile the services binary and name it in such a way that it can be used as a plugin to `oc` - using `oc services promote ...` for example.
 
-A Dockerfile is also provided that will pull in `oc` and copy the built plugin binary into that image. You could then push that image to your own testing place on DOckerhub for use later - be it as a standalone container or as part of a Tekton Task.
+A Dockerfile is also provided that will pull in `oc` and copy the built plugin binary into that image. You could then push that image to your own testing place on Dockerhub for use later - be it as a standalone container or as part of a Tekton Task.
 
 Build it with the following command from the main `services` folder:
 
@@ -9,7 +9,5 @@ Build it with the following command from the main `services` folder:
 You can then do
 
 `docker run -e GITHUB_TOKEN=<mytoken> <dockerusername>/oc-services-plugin-experiment:latest services promote --from https://github.com/myorg/myrepo --to https://github.com/myorg/myotherrepo --service myservicename --commit-name=<mygitname> --commmit-email=<mygitemail>`
-
-But you need Git details too
 
 and that's using `promote` but from being an `oc plugin` - useful for seeing if anything breaks.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -8,6 +8,8 @@ Build it with the following command from the main `services` folder:
 
 You can then do
 
-`docker run -e GITHUB_TOKEN=<mytoken> <dockerusername>/oc-services-plugin-experiment:latest services promote`
+`docker run -e GITHUB_TOKEN=<mytoken> <dockerusername>/oc-services-plugin-experiment:latest services promote --from https://github.com/myorg/myrepo --to https://github.com/myorg/myotherrepo --service myservicename --commit-name=<mygitname> --commmit-email=<mygitemail>`
+
+But you need Git details too
 
 and that's using `promote` but from being an `oc plugin` - useful for seeing if anything breaks.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,3 @@
+This folder contains an example script that will compile the services binary and name it in such a way that it can be used as a plugin to `oc` - using `oc services promote ...` for example.
+
+A Dockerfile is also provided that will pull in `oc` and copy the built plugin binary into that image. You could then push that image to your own testing place on DOckerhub for use later - be it as a standalone container or as part of a Tekton Task.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -8,6 +8,6 @@ Build it with the following command from the main `services` folder:
 
 You can then do
 
-`docker run <dockerusername>/oc-services-plugin-experiment:latest promote`
+`docker run <dockerusername>/oc-services-plugin-experiment:latest services promote`
 
-and that's using promote but from being an `oc plugin` - useful for seeing if anything breaks.
+and that's using `promote` but from being an `oc plugin` - useful for seeing if anything breaks.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -5,3 +5,9 @@ A Dockerfile is also provided that will pull in `oc` and copy the built plugin b
 Build it with the following command from the main `services` folder:
 
 `docker build -f plugin/Dockerfile -t <dockerusername>/oc-services-plugin-experiment .` 
+
+You can then do
+
+`docker run <dockerusername>/oc-services-plugin-experiment:latest promote`
+
+and that's using promote but from being an `oc plugin` - useful for seeing if anything breaks.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,3 +1,7 @@
 This folder contains an example script that will compile the services binary and name it in such a way that it can be used as a plugin to `oc` - using `oc services promote ...` for example.
 
 A Dockerfile is also provided that will pull in `oc` and copy the built plugin binary into that image. You could then push that image to your own testing place on DOckerhub for use later - be it as a standalone container or as part of a Tekton Task.
+
+Build it with the following command from the main `services` folder:
+
+`docker build -f plugin/Dockerfile -t <dockerusername>/oc-services-plugin-experiment .` 

--- a/plugin/make-plugin.sh
+++ b/plugin/make-plugin.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+go build ./cmd/services
+mv ./services ./oc-services
+chmod +x ./oc-services
+sudo mv ./oc-services /usr/local/bin/
+oc services --help

--- a/tekton-example/README.md
+++ b/tekton-example/README.md
@@ -67,9 +67,9 @@ This example promotes from the `promote-demo` repository, containing a service w
 Optionally, you can run a subsequent promote from one GitOps repository to another (e.g staging to prod) after merging the pull request on your first GitOps repository. For this you will need a third repository, and for this you can fork: https://github.com/rhd-gitops-example/gitops-example-staging
 
 -  To do this second promote, you will need to create a TaskRun that executes a task promoting from a testing repository to a production repository
-- To create the TaskRun, use:
+- To create the TaskRun (again this uses a service called `promote-demo`), use:
 ```shell
-tkn task start promote --param github-secret=promote-secret--param from=https://github.com/<github username>/<github repo> --param from=https://github.com/<github username>/<github repo>.git --param commit-name=<mygithubname> --param commit-email=<mygithubmail> --param service=service-a -s demo --showlog
+tkn task start promote --param github-secret=promote-secret --param from=https://github.com/<yourorg>/<yourdevrepo>.git --param to=https://github.com/<yourorg>/<yourstagingrepo>.git --param commit-name=<yourgitname> --param commit-email=<yourgitemail> --param service=promote-demo -s demo --showlog
 ```
 This will start the TaskRun and output its logs, and you can also view its progress in the Tekton Dashboard.
 

--- a/tekton-example/README.md
+++ b/tekton-example/README.md
@@ -14,7 +14,6 @@ Creation of a TaskRun (using `promote-run.yaml`) will then further promote from 
 - `service-promote-pipeline.yaml`: Creates a pipeline that executes `build-task.yaml` and `service-promote.yaml`
 - `promote.yaml`: Creates a pull request from one repository to another repository
 - `build-task.yaml`: This task builds a git source into a docker image and pushes to a docker registry
-- `gitconfig`: Data file for the configmap - includes a GitHub user ID and email address
 
 ## Pre-requisites
 
@@ -47,13 +46,6 @@ kubectl apply -f resources
 ```shell 
 kubectl apply -f templates
 ```
-- Edit `gitconfig` to contain your GitHub username and email address
-
-- Create a configmap:
-```shell
-kubectl create configmap promote-configmap --from-file=gitconfig
-```
-This will store your GitHub username and email address in key-value pairs that can be used in the PipelineRun. 
 
 ## Execute Pipeline
 
@@ -61,7 +53,7 @@ The PipelineRun you will create is designed to build your microservice from its 
 
 - To create the PipelineRun, use:
 ```shell
-tkn pipeline start service-promote-pipeline --resource git-source=git-app-repo --resource docker-image=docker-app-image--param commitID=v1 --param github-secret=promote-secret --param github-config=promote-configmap --param to=https://github.com/<github username>/<github repo>.git --workspace name=repo-space,claimName=repopvc,subPath=dir -s demo --showlog
+tkn pipeline start service-promote-pipeline --resource git-source=git-app-repo --resource docker-image=docker-app-image--param commitID=v1 --param github-secret=promote-secret --param commit-name=<yourgitname> --param commit-email=<yourgitemail> --param to=https://github.com/<github username>/<github repo>.git --workspace name=repo-space,claimName=repopvc,subPath=dir -s demo --showlog
 ```
 
 - This creates a PipelineRun that executes the `service-promote-pipeline`, which will build the code and promote it to a repository you have specified
@@ -74,7 +66,7 @@ Optionally, you can run a subsequent promote from one GitOps repository to anoth
 -  To do this second promote, you will need to create a TaskRun that executes a task promoting from a testing repository to a production repository
 - To create the TaskRun, use:
 ```shell
-tkn task start promote --param github-secret=promote-secret--param from=https://github.com/<github username>/<github repo> --param from=https://github.com/<github username>/<github repo>.git --param github-config=promote-configmap --param service=service-a -s demo --showlog
+tkn task start promote --param github-secret=promote-secret--param from=https://github.com/<github username>/<github repo> --param from=https://github.com/<github username>/<github repo>.git --param commit-name=<mygithubname> --param commit-email=<mygithubmail> --param service=service-a -s demo --showlog
 ```
 This will start the TaskRun and output its logs, and you can also view its progress in the Tekton Dashboard.
 

--- a/tekton-example/README.md
+++ b/tekton-example/README.md
@@ -53,8 +53,11 @@ The PipelineRun you will create is designed to build your microservice from its 
 
 - To create the PipelineRun, use:
 ```shell
-tkn pipeline start service-promote-pipeline --resource git-source=git-app-repo --resource docker-image=docker-app-image--param commitID=v1 --param github-secret=promote-secret --param commit-name=<yourgitname> --param commit-email=<yourgitemail> --param to=https://github.com/<github username>/<github repo>.git --workspace name=repo-space,claimName=repopvc,subPath=dir -s demo --showlog
+tkn pipeline start service-promote-pipeline --resource git-source=git-app-repo --resource docker-image=docker-app-image--param commitId=v1 --param github-secret=promote-secret --param commit-name=<yourgitname> --param commit-email=<yourgitemail> --param to=https://github.com/<github username>/<github repo>.git --param service=promote-demo --workspace name=repo-space,claimName=repopvc,subPath=dir -s demo --showlog
 ```
+
+This example promotes from the `promote-demo` repository, containing a service with the same name.
+
 
 - This creates a PipelineRun that executes the `service-promote-pipeline`, which will build the code and promote it to a repository you have specified
 - The logs will be outputted to your console, and you can also view its progress in the Tekton Dashboard.

--- a/tekton-example/gitconfig
+++ b/tekton-example/gitconfig
@@ -1,3 +1,0 @@
-[user]
-	name = REPLACE_ME.GITHUB_USERNAME
-	email = REPLACE_ME.GITHUB_EMAIL

--- a/tekton-example/resources/promote.yaml
+++ b/tekton-example/resources/promote.yaml
@@ -16,27 +16,19 @@ spec:
   - name: service
     type: string
     description: service name to be promoted
-  - name: github-config
+  - name: commit-name
     type: string
-    description: configmap name of the gitconfig file that has user name, user e-mail
-  volumes:
-  - name: gitconfig
-    configMap:
-      name: $(params.github-config)
-      items:
-        - key: gitconfig
-          path: gitconfig
+    description: the GitHub username to username
+  - name: commit-email
+    type: string
+    description: the GitHub email to use
   steps:
   - name: promote
     image: quay.io/redhat-developer/gitops-cli
     imagePullPolicy: Always
-    volumeMounts:
-    - name: gitconfig
-      mountPath: /root
     script: |
       #!/bin/sh
-      cp /root/gitconfig $HOME/.gitconfig
-      services promote --from $(params.from) --to $(params.to) --service $(params.service) 
+      services promote --commit-name=$(params.commit-name) --commit-email=$(params.commit-email) --from $(params.from) --to $(params.to) --service $(params.service)
     env:
     - name: GITHUB_TOKEN
       valueFrom:

--- a/tekton-example/resources/service-promote-pipeline.yaml
+++ b/tekton-example/resources/service-promote-pipeline.yaml
@@ -69,7 +69,7 @@ spec:
     - name: commit-name
       value: $(params.commit-name)
     - name: commit-email
-      value: $(params.commit-name)
+      value: $(params.commit-email)
 
 
 

--- a/tekton-example/resources/service-promote-pipeline.yaml
+++ b/tekton-example/resources/service-promote-pipeline.yaml
@@ -22,9 +22,12 @@ spec:
   - name: service
     type: string
     description: service name to be promoted
-  - name: github-config
+  - name: commit-name
     type: string
-    description: configmap name of the gitconfig file that has user name, user e-mail.  The key name is gitco
+    description: the GitHub name to use on the commit
+  - name: commit-email
+    type: string
+    description: the GitHub email to use on the commit
   resources: 
   - name: git-source
     type: git
@@ -63,8 +66,10 @@ spec:
       value: $(params.to)
     - name: service
       value: $(params.service)
-    - name: github-config
-      value: $(params.github-config)
+    - name: commit-name
+      value: $(params.commit-name)
+    - name: commit-email
+      value: $(params.commit-name)
 
 
 

--- a/tekton-example/resources/service-promote.yaml
+++ b/tekton-example/resources/service-promote.yaml
@@ -25,26 +25,15 @@ spec:
   - name: commit-email
     type: string
     description: the GitHub email to use
-  volumes:
-  - name: gitconfig
-    configMap:
-      name: $(params.github-config)
-      items:
-        - key: gitconfig
-          path: gitconfig
   steps:
   - name: promote
     image: quay.io/redhat-developer/gitops-cli
     imagePullPolicy: Always
-    volumeMounts:
-    - name: gitconfig
-      mountPath: /root
     script: |
       #!/bin/sh -x
-      cp /root/gitconfig $HOME/.gitconfig
       cd $(params.from)
       gitCommit=$(git rev-parse --short HEAD)
-      services promote --from $(params.from) --to $(params.to) --service $(params.service) --commit-message "Publish $(params.service) commit $gitCommit" --commit-name=$(params.commit-name) --commit-email=$(params.commit-email)
+      services promote  --commit-name=$(params.commit-name) --commit-email=$(params.commit-email) --from $(params.from) --to $(params.to) --service $(params.service) --commit-message "Publish $(params.service) commit $gitCommit"
     env:
     - name: GITHUB_TOKEN
       valueFrom:

--- a/tekton-example/resources/service-promote.yaml
+++ b/tekton-example/resources/service-promote.yaml
@@ -11,17 +11,20 @@ spec:
     description: name of the secret that contains the GitHub access token, the access token must be in a token key.
   - name: from
     type: string
-    description: github repository url to be promoted from
+    description: GitHub repository URL to be promoted from
     default: /workspace/repo
   - name: to
     type: string
-    description: github repository url to be promoted to
+    description: GitHub repository URL to be promoted to
   - name: service
     type: string
     description: service name to be promoted
-  - name: github-config
+  - name: commit-name
     type: string
-    description: configmap name of the gitconfig file that has user name and e-mail
+    description: the GitHub username to username
+  - name: commit-email
+    type: string
+    description: the GitHub email to use
   volumes:
   - name: gitconfig
     configMap:
@@ -41,7 +44,7 @@ spec:
       cp /root/gitconfig $HOME/.gitconfig
       cd $(params.from)
       gitCommit=$(git rev-parse --short HEAD)
-      services promote --from $(params.from) --to $(params.to) --service $(params.service) --commit-message "Publish $(params.service) commit $gitCommit"
+      services promote --from $(params.from) --to $(params.to) --service $(params.service) --commit-message "Publish $(params.service) commit $gitCommit" --commit-name=$(params.commit-name) --commit-email=$(params.commit-email)
     env:
     - name: GITHUB_TOKEN
       valueFrom:


### PR DESCRIPTION
The current state of this is: it works, but it's not the tidiest and can certainly be optimised.

By the following the example docs I've added you end up with a Docker container with `oc` and our `services` binary, with a `run` example, and you'll be running as an `oc` plugin.

I had to make additional changes here so that user.Name and user.Email were picked up correctly (suggesting we've got a bug otherwise, or this could be specific to running as a plugin).

^^ I'll test this part once I figure out where our Docker image is

@bigkevmcd @mnuttall FYI

Closes https://github.com/rhd-gitops-example/services/issues/80

Todo: working on incorporating this into the Tekton example.