### PR TITLE
Clean repository URL for error display

### DIFF
--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -223,7 +223,11 @@ func repoName(u string) (string, error) {
 	}
 	parts := strings.Split(parsed.Path, "/")
 	if len(parts) < 3 {
-		return "", fmt.Errorf("could not identify repository name: %s", u)
+		cleanedURL, err := CleanURL(u)
+		if err != nil {
+			return "", errors.New("failed to clean the URL when determining repository name")
+		}
+		return "", fmt.Errorf("could not identify repository name: %s", cleanedURL)
 	}
 	return strings.TrimSuffix(parts[len(parts)-1], ".git"), nil
 }


### PR DESCRIPTION
For: https://github.com/rhd-gitops-example/services/issues/85
- Cleans the URL at the source of the error creation so that the access token will not be present in the error:
```
2020/05/29 13:17:39 failed to clone destination repository, error: failed to clone repository, error is: could not identify repository name: https://github.com/gitops-example-dev. repository URL = https://github.com/gitops-example-dev. repository URL = https://github.com/gitops-example-dev. repository URL = https://github.com/gitops-example-dev
```