### PR TITLE
Update automerge-example to use commit-name and commit-email

### DIFF
--- a/automerge-example/README.md
+++ b/automerge-example/README.md
@@ -63,7 +63,7 @@ Create or modify an existing ServiceAccount to use your `github-secret` (hint, y
 Finally start the Tekton pipeline referencing your ServiceAccount:
 
 ```sh
-tkn pipeline start automerge-pipeline -r source-repo=gitops-repo -r pr=pull-request -p github-config=promoteconfigmap -p github-secret=github-secret --showlog -s my-sa
+tkn pipeline start automerge-pipeline -r source-repo=gitops-repo -r pr=pull-request -p commit-name=<yourgitname> -p commit-email=<yourgitemail> -p github-secret=github-secret --showlog -s my-sa
 ```
 
 The pipeline will do a dry run to test that the yaml in the Pull Request is good, then merge the Pull Request and delete the branch associated with it.

--- a/automerge-example/standalone/resources/automerge-pipeline.yaml
+++ b/automerge-example/standalone/resources/automerge-pipeline.yaml
@@ -6,8 +6,12 @@ spec:
   params:
   - name: github-secret
     type: string
-  - name: github-config
+  - name: commit-name
     type: string
+    description: the GitHub name to use on the commit
+  - name: commit-email
+    type: string
+    description: the GitHub email to use on the commit
   resources: 
   - name: source-repo
     type: git
@@ -26,5 +30,7 @@ spec:
     params:
     - name: github-secret
       value: $(params.github-secret)
-    - name: github-config
-      value: $(params.github-config)
+    - name: commit-name
+      value: $(params.commit-name)
+    - name: commit-email
+      value: $(params.commit-email)


### PR DESCRIPTION
Updates the automerge example to remove references to `promoteconfigmap` in the README and in the pipeline, replacing with `commit-name` and `commit-email` to be consistent with the rest of this example and the tekton-example