### PR TITLE
Rename package avancement

### DIFF
--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -6,8 +6,8 @@ import (
 	"log"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/rhd-gitops-example/services/pkg/avancement"
 	"github.com/rhd-gitops-example/services/pkg/git"
+	"github.com/rhd-gitops-example/services/pkg/promotion"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tcnksm/go-gitconfig"
@@ -128,7 +128,7 @@ func promoteAction(c *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return avancement.New(cacheDir, author, avancement.WithDebug(debug), avancement.WithInsecureSkipVerify(insecureSkipVerify), avancement.WithRepoType(repoType)).Promote(service, fromRepo, toRepo, newBranchName, msg, keepCache)
+	return promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType)).Promote(service, fromRepo, toRepo, newBranchName, msg, keepCache)
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -1,4 +1,4 @@
-package avancement
+package promotion
 
 import (
 	"fmt"

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -1,4 +1,4 @@
-package avancement
+package promotion
 
 import (
 	"testing"

--- a/pkg/promotion/service_manager.go
+++ b/pkg/promotion/service_manager.go
@@ -1,4 +1,4 @@
-package avancement
+package promotion
 
 import (
 	"context"
@@ -246,7 +246,6 @@ func (s *ServiceManager) cloneRepo(repoURL, branch string) (git.Repo, error) {
 func createPullRequest(ctx context.Context, fromURL, toURL, newBranchName, commitMsg string, client *scm.Client, fromLocal bool) (*scm.PullRequest, error) {
 	prInput, err := makePullRequestInput(fromLocal, fromURL, toURL, newBranchName, commitMsg)
 	if err != nil {
-		// TODO: improve this error message
 		return nil, err
 	}
 

--- a/pkg/promotion/service_manager_test.go
+++ b/pkg/promotion/service_manager_test.go
@@ -1,4 +1,4 @@
-package avancement
+package promotion
 
 import (
 	"errors"


### PR DESCRIPTION
Also removes an unnecessary TODO statement, found as part of #98. The one place that calls the `createPullRequest` with the TODO note wraps the error and provides the necessary information to the user:
```
	pr, err := createPullRequest(ctx, fromURL, toURL, newBranchName, commitMsg, s.clientFactory(s.author.Token, toURL, s.repoType, s.tlsVerify), isLocal)
	if err != nil {
		message := fmt.Sprintf("failed to create a pull-request for branch %s, error: %s", newBranchName, err)
		return git.GitError(message, toURL)
	}
```

So I don't think it's necessary to improve the message in `createPullRequest`.

I *think* that avancement / advancement was just a typo, but please correct me if I'm wrong.