### PR TITLE
Fix automerge PipelineResources for Tekton 0.12 

### DIFF
--- a/automerge-example/standalone/templates/automerge-task.yaml
+++ b/automerge-example/standalone/templates/automerge-task.yaml
@@ -32,6 +32,8 @@ spec:
       fullPRLink=$(yq r pull-request/pr.json 'Link')
       prURL=${fullPRLink%.diff}
 
+      git config --global user.name $(params.commit-name)
+      git config --global user.email $(params.commit-email)
       cd git-source
       hub merge $prURL
       git push -u origin master

--- a/automerge-example/standalone/templates/git-resource.yaml
+++ b/automerge-example/standalone/templates/git-resource.yaml
@@ -8,4 +8,6 @@ spec:
     value: master
   - name: url
     value: https://github.com/YOUR_GITHUB_ID/gitops-example-dev
+  - name: refspec
+    value: refs/heads/*:refs/heads/*
   type: git

--- a/automerge-example/standalone/templates/git-resource.yaml
+++ b/automerge-example/standalone/templates/git-resource.yaml
@@ -10,4 +10,6 @@ spec:
     value: https://github.com/YOUR_GITHUB_ID/gitops-example-dev
   - name: refspec
     value: refs/heads/*:refs/heads/*
+  - name: depth
+    value: "0"
   type: git

--- a/automerge-example/webhooks/templates/automerge-tt.yaml
+++ b/automerge-example/webhooks/templates/automerge-tt.yaml
@@ -38,6 +38,8 @@ spec:
           value: master
         - name: url
           value: $(params.gitrepositoryurl)
+        - name: refspec
+          value: refs/heads/*:refs/heads/*
         type: git
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun

--- a/automerge-example/webhooks/templates/automerge-tt.yaml
+++ b/automerge-example/webhooks/templates/automerge-tt.yaml
@@ -40,6 +40,8 @@ spec:
           value: $(params.gitrepositoryurl)
         - name: refspec
           value: refs/heads/*:refs/heads/*
+        - name: depth
+          value: "0"
         type: git
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun


### PR DESCRIPTION
Also fixes standalone Task for git name and email, which had been dropped accidentally. 

Resolves https://github.com/rhd-gitops-example/services/issues/83