### PR TITLE
Expose branch-name flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ This will again raise a Pull Request, copying the local files `/workspace/servic
 ## CLI Reference
 
 ```sh
-services promote --help
 promote from one environment to another
 
 Usage:
   services promote [flags]
 
 Flags:
+      --branch-name string       the name of the branch on the destination repository for the pull request
       --cache-dir string         where to cache Git checkouts (default "~/.promotion/cache")
       --commit-email string      the email to use for commits when creating branches
       --commit-message string    the msg to use on the resultant commit and pull request
@@ -89,6 +89,7 @@ Global Flags:
 
 This will _copy_ all files under `/services/service-a/base/config/*` in `first-environment` to `second-environment`, commit and push, and open a PR for the change. Any of these arguments may be provided as environment variables, using all upper case and replacing `-` with `_`. Hence you can set CACHE_DIR, COMMIT_EMAIL, etc.
 
+- `--branch-name` : use this to override the branch name on the destination Git repository, which will otherwise be generated automatically.
 - `--cache-dir` : path on the local filesystem in which Git checkouts will be cached.
 - `--commit-email` : Git commits require an associated email address and username. This is the email address. May be set via ~/.gitconfig.
 - `--commit-message` : use this to override the commit message which will otherwise be generated automatically.
@@ -117,3 +118,4 @@ Inside of the `plugin` folder you'll see documentation and other files related t
 Client Version: openshift-clients-4.3.13-202004121622
 Server Version: 4.3.13
 Kubernetes Version: v1.16.2
+```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This will again raise a Pull Request, copying the local files `/workspace/servic
 ## CLI Reference
 
 ```sh
+services promote --help
 promote from one environment to another
 
 Usage:

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -20,6 +20,7 @@ func makePromoteCmd() *cobra.Command {
 		RunE:  promoteAction,
 	}
 
+	// Required flags
 	cmd.Flags().String(
 		fromFlag,
 		"",
@@ -44,19 +45,20 @@ func makePromoteCmd() *cobra.Command {
 	logIfError(cmd.MarkFlagRequired(serviceFlag))
 	logIfError(viper.BindPFlag(serviceFlag, cmd.Flags().Lookup(serviceFlag)))
 
+	// Optional flags
+	cmd.Flags().String(
+		branchNameFlag,
+		"",
+		"the name of the branch on the destination repository for the pull request (auto-generated if empty)",
+	)
+	logIfError(viper.BindPFlag(branchNameFlag, cmd.Flags().Lookup(branchNameFlag)))
+
 	cmd.Flags().String(
 		cacheDirFlag,
 		"~/.promotion/cache",
 		"where to cache Git checkouts",
 	)
 	logIfError(viper.BindPFlag(cacheDirFlag, cmd.Flags().Lookup(cacheDirFlag)))
-
-	cmd.Flags().String(
-		nameFlag,
-		"",
-		"the name to use for commits when creating branches",
-	)
-	logIfError(viper.BindPFlag(nameFlag, cmd.Flags().Lookup(nameFlag)))
 
 	cmd.Flags().String(
 		emailFlag,
@@ -73,11 +75,11 @@ func makePromoteCmd() *cobra.Command {
 	logIfError(viper.BindPFlag(msgFlag, cmd.Flags().Lookup(msgFlag)))
 
 	cmd.Flags().String(
-		repoTypeFlag,
-		"github",
-		"the type of repository: github, gitlab or ghe",
+		nameFlag,
+		"",
+		"the name to use for commits when creating branches",
 	)
-	logIfError(viper.BindPFlag(repoTypeFlag, cmd.Flags().Lookup(repoTypeFlag)))
+	logIfError(viper.BindPFlag(nameFlag, cmd.Flags().Lookup(nameFlag)))
 
 	cmd.Flags().Bool(
 		debugFlag,
@@ -99,6 +101,13 @@ func makePromoteCmd() *cobra.Command {
 		"whether to retain the locally cloned repositories in the cache directory",
 	)
 	logIfError(viper.BindPFlag(keepCacheFlag, cmd.Flags().Lookup(keepCacheFlag)))
+
+	cmd.Flags().String(
+		repoTypeFlag,
+		"github",
+		"the type of repository: github, gitlab or ghe",
+	)
+	logIfError(viper.BindPFlag(repoTypeFlag, cmd.Flags().Lookup(repoTypeFlag)))
 	return cmd
 }
 
@@ -109,15 +118,18 @@ func logIfError(e error) {
 }
 
 func promoteAction(c *cobra.Command, args []string) error {
+	// Required flags
 	fromRepo := viper.GetString(fromFlag)
 	toRepo := viper.GetString(toFlag)
 	service := viper.GetString(serviceFlag)
-	repoType := viper.GetString(repoTypeFlag)
+
+	// Optional flags
 	newBranchName := viper.GetString(branchNameFlag)
-	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
-	debug := viper.GetBool(debugFlag)
-	keepCache := viper.GetBool(keepCacheFlag)
 	msg := viper.GetString(msgFlag)
+	debug := viper.GetBool(debugFlag)
+	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
+	keepCache := viper.GetBool(keepCacheFlag)
+	repoType := viper.GetString(repoTypeFlag)
 
 	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
 	if err != nil {


### PR DESCRIPTION
Also re-orders the flags so that they more closely match the help
output, but required flags are still at the top.

For #103