### PR TITLE
Add options for from-branch and to-branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Usage:
   services promote [flags]
 
 Flags:
-      --branch-name string       the name of the branch on the destination repository for the pull request
+      --branch-name string       the name of the branch on the destination repository for the pull request (auto-generated if empty)
       --cache-dir string         where to cache Git checkouts (default "~/.promotion/cache")
       --commit-email string      the email to use for commits when creating branches
       --commit-message string    the msg to use on the resultant commit and pull request
@@ -85,6 +85,7 @@ Flags:
       --service string           service name to promote
       --to string                destination Git repository
       --to-branch string         branch on the destination Git repository (default "master")
+
 Global Flags:
       --github-token string   oauth access token to authenticate the request
 ```

--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ Flags:
       --commit-name string       the name to use for commits when creating branches
       --debug                    additional debug logging output
       --from string              source Git repository
+      --from-branch string       branch on the source Git repository (default "master")
   -h, --help                     help for promote
       --insecure-skip-verify     Insecure skip verify TLS certificate
       --keep-cache               whether to retain the locally cloned repositories in the cache directory
       --repository-type string   the type of repository: github, gitlab or ghe (default "github")
       --service string           service name to promote
       --to string                destination Git repository
-
+      --to-branch string         branch on the destination Git repository (default "master")
 Global Flags:
       --github-token string   oauth access token to authenticate the request
 ```
@@ -97,12 +98,14 @@ This will _copy_ all files under `/services/service-a/base/config/*` in `first-e
 - `--commit-name` : The other half of `commit-email`. Both must be set.
 - `--debug` : prints extra debug output if true.
 - `--from` : an https URL to a GitOps repository for 'remote' cases, or a path to a Git clone of a microservice for 'local' cases.
+- `--from-branch` : use this to specify a branch on the source repository, instead of using the "master" branch.
 - `--help`: prints the above text if true.
 - `--insecure-skip-verify` : skip TLS cerificate verification if true. Do not set this to true unless you know what you are doing.
 - `--keep-cache` : `cache-dir` is deleted unless this is set to true. Keeping the cache will often cause further promotion attempts to fail. This flag is mostly used along with `--debug` when investigating failure cases. 
 - `--repository-type` : the type of repository: github, gitlab or ghe (default "github"). If `--from` is a Git URL, it must be of the same type as that specified via `--to`.
 - `--service` : the destination path for promotion is `/environments/<env-name>/services/<service-name>/base/config/`. This argument defines `service-name` in that path.
 - `--to`: an https URL to the destination GitOps repository.
+- `--to-branch` : use this to specify a branch on the destination repository, instead of using the "master" branch.
 
 ### Troubleshooting
 

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -139,7 +139,6 @@ func promoteAction(c *cobra.Command, args []string) error {
 
 	// Optional flags
 	newBranchName := viper.GetString(branchNameFlag)
-	msg := viper.GetString(msgFlag)
 	debug := viper.GetBool(debugFlag)
 	fromBranch := viper.GetString(fromBranchFlag)
 	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
@@ -157,7 +156,18 @@ func promoteAction(c *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType)).Promote(service, fromRepo, fromBranch, toRepo, toBranch, newBranchName, msg, keepCache)
+
+	from := promotion.EnvLocale{
+		Path:   fromRepo,
+		Branch: fromBranch,
+	}
+	to := promotion.EnvLocale{
+		Path:   toRepo,
+		Branch: toBranch,
+	}
+
+	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -157,13 +157,13 @@ func promoteAction(c *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
 
-	from := promotion.EnvLocale{
-		Path:   fromRepo,
-		Branch: fromBranch,
+	from := promotion.EnvLocation{
+		RepoPath: fromRepo,
+		Branch:   fromBranch,
 	}
-	to := promotion.EnvLocale{
-		Path:   toRepo,
-		Branch: toBranch,
+	to := promotion.EnvLocation{
+		RepoPath: toRepo,
+		Branch:   toBranch,
 	}
 
 	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -88,6 +88,13 @@ func makePromoteCmd() *cobra.Command {
 	)
 	logIfError(viper.BindPFlag(debugFlag, cmd.Flags().Lookup(debugFlag)))
 
+	cmd.Flags().String(
+		fromBranchFlag,
+		"master",
+		"branch on the source Git repository",
+	)
+	logIfError(viper.BindPFlag(fromBranchFlag, cmd.Flags().Lookup(fromBranchFlag)))
+
 	cmd.Flags().Bool(
 		insecureSkipVerifyFlag,
 		false,
@@ -108,6 +115,13 @@ func makePromoteCmd() *cobra.Command {
 		"the type of repository: github, gitlab or ghe",
 	)
 	logIfError(viper.BindPFlag(repoTypeFlag, cmd.Flags().Lookup(repoTypeFlag)))
+
+	cmd.Flags().String(
+		toBranchFlag,
+		"master",
+		"branch on the source Git repository",
+	)
+	logIfError(viper.BindPFlag(toBranchFlag, cmd.Flags().Lookup(toBranchFlag)))
 	return cmd
 }
 
@@ -127,9 +141,12 @@ func promoteAction(c *cobra.Command, args []string) error {
 	newBranchName := viper.GetString(branchNameFlag)
 	msg := viper.GetString(msgFlag)
 	debug := viper.GetBool(debugFlag)
+	fromBranch := viper.GetString(fromBranchFlag)
 	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
 	keepCache := viper.GetBool(keepCacheFlag)
+	msg := viper.GetString(msgFlag)
 	repoType := viper.GetString(repoTypeFlag)
+	toBranch := viper.GetString(toBranchFlag)
 
 	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
 	if err != nil {
@@ -140,7 +157,7 @@ func promoteAction(c *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType)).Promote(service, fromRepo, toRepo, newBranchName, msg, keepCache)
+	return promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType)).Promote(service, fromRepo, fromBranch, toRepo, toBranch, newBranchName, msg, keepCache)
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -119,7 +119,7 @@ func makePromoteCmd() *cobra.Command {
 	cmd.Flags().String(
 		toBranchFlag,
 		"master",
-		"branch on the source Git repository",
+		"branch on the destination Git repository",
 	)
 	logIfError(viper.BindPFlag(toBranchFlag, cmd.Flags().Lookup(toBranchFlag)))
 	return cmd
@@ -139,11 +139,11 @@ func promoteAction(c *cobra.Command, args []string) error {
 
 	// Optional flags
 	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
 	debug := viper.GetBool(debugFlag)
 	fromBranch := viper.GetString(fromBranchFlag)
 	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
 	keepCache := viper.GetBool(keepCacheFlag)
-	msg := viper.GetString(msgFlag)
 	repoType := viper.GetString(repoTypeFlag)
 	toBranch := viper.GetString(toBranchFlag)
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -23,6 +23,8 @@ const (
 	insecureSkipVerifyFlag = "insecure-skip-verify"
 	debugFlag              = "debug"
 	keepCacheFlag          = "keep-cache"
+	fromBranchFlag         = "from-branch"
+	toBranchFlag           = "to-branch"
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -10,21 +10,21 @@ import (
 )
 
 const (
-	githubTokenFlag        = "github-token"
 	branchNameFlag         = "branch-name"
-	fromFlag               = "from"
-	toFlag                 = "to"
-	serviceFlag            = "service"
-	repoTypeFlag           = "repository-type"
 	cacheDirFlag           = "cache-dir"
+	emailFlag              = "commit-email"
 	msgFlag                = "commit-message"
 	nameFlag               = "commit-name"
-	emailFlag              = "commit-email"
-	insecureSkipVerifyFlag = "insecure-skip-verify"
 	debugFlag              = "debug"
-	keepCacheFlag          = "keep-cache"
+	fromFlag               = "from"
 	fromBranchFlag         = "from-branch"
+	insecureSkipVerifyFlag = "insecure-skip-verify"
+	keepCacheFlag          = "keep-cache"
+	repoTypeFlag           = "repository-type"
+	serviceFlag            = "service"
+	toFlag                 = "to"
 	toBranchFlag           = "to-branch"
+	githubTokenFlag        = "github-token"
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/promotion/promote.go
+++ b/pkg/promotion/promote.go
@@ -1,0 +1,160 @@
+package promotion
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/rhd-gitops-example/services/pkg/git"
+	"github.com/rhd-gitops-example/services/pkg/local"
+
+	"github.com/google/uuid"
+	"github.com/jenkins-x/go-scm/scm"
+)
+
+type EnvLocale struct {
+	Path   string // URL or local path
+	Branch string
+}
+
+func (env EnvLocale) IsLocal() bool {
+	parsed, err := url.Parse(env.Path)
+	if err != nil {
+		log.Printf("Error while parsing URL for environment path: '%v', assuming it is local.\n", err)
+		return true
+	}
+	return parsed.Scheme == ""
+}
+
+// Promote is the main driver for promoting files between two
+// repositories.
+//
+// It uses a Git cache to checkout the code to, and will copy the environment
+// configuration for the `fromURL` to the `toURL` in a named branch.
+func (s *ServiceManager) Promote(serviceName string, from, to EnvLocale, newBranchName, message string, keepCache bool) error {
+	var reposToDelete []git.Repo
+	if !keepCache {
+		defer clearCache(&reposToDelete)
+	}
+
+	var source git.Source
+	var err error
+	if from.IsLocal() {
+		source = s.localFactory(from.Path, s.debug)
+	} else {
+		source, err = s.checkoutSourceRepo(from.Path, from.Branch)
+		if err != nil {
+			return git.GitError("error checking out source repository from Git", from.Path)
+		}
+		reposToDelete = append(reposToDelete, source.(git.Repo))
+	}
+	if newBranchName == "" {
+		newBranchName = generateBranchName(source)
+	}
+
+	destination, err := s.checkoutDestinationRepo(to.Path, newBranchName)
+	if err != nil {
+		return err
+	}
+	reposToDelete = append(reposToDelete, destination)
+	destinationEnvironment, err := destination.GetUniqueEnvironmentFolder()
+	if err != nil {
+		return fmt.Errorf("could not determine unique environment name for destination repository - check that only one directory exists under it and you can write to your cache folder")
+	}
+
+	var copied []string
+	if from.IsLocal() {
+		copied, err = local.CopyConfig(serviceName, source, destination, destinationEnvironment)
+		if err != nil {
+			return fmt.Errorf("failed to set up local repository: %w", err)
+		}
+	} else {
+		repo, ok := source.(git.Repo)
+		if !ok {
+			// should not happen, but just in case
+			return fmt.Errorf("failed to convert source '%v' to Git Repo", source)
+		}
+		sourceEnvironment, err := repo.GetUniqueEnvironmentFolder()
+		if err != nil {
+			return fmt.Errorf("could not determine unique environment name for source repository - check that only one directory exists under it and you can write to your cache folder")
+		}
+
+		copied, err = git.CopyService(serviceName, source, destination, sourceEnvironment, destinationEnvironment)
+		if err != nil {
+			return fmt.Errorf("failed to copy service: %w", err)
+		}
+	}
+
+	if message == "" {
+		message = generateDefaultCommitMsg(source, serviceName, from)
+	}
+	if err := destination.StageFiles(copied...); err != nil {
+		return fmt.Errorf("failed to stage files %s: %w", copied, err)
+	}
+	if err := destination.Commit(message, s.author); err != nil {
+		return fmt.Errorf("failed to commit: %w", err)
+	}
+	if err := destination.Push(newBranchName); err != nil {
+		return fmt.Errorf("failed to push to Git repository - check the access token is correct with sufficient permissions: %w", err)
+	}
+
+	ctx := context.Background()
+	pr, err := createPullRequest(ctx, from, to, newBranchName, message, s.clientFactory(s.author.Token, to.Path, s.repoType, s.tlsVerify))
+	if err != nil {
+		message := fmt.Sprintf("failed to create a pull-request for branch %s, error: %s", newBranchName, err)
+		return git.GitError(message, to.Path)
+	}
+	log.Printf("created PR %d", pr.Number)
+	return nil
+}
+
+func clearCache(repos *[]git.Repo) {
+	for _, repo := range *repos {
+		err := repo.DeleteCache()
+		if err != nil {
+			log.Printf("failed deleting files from cache: %s", err)
+		}
+	}
+}
+
+// generateBranchName constructs a branch name based on the source (a commit or local) and
+// a random UUID
+func generateBranchName(source git.Source) string {
+	var commitID string
+	repo, ok := source.(git.Repo)
+	if ok {
+		commitID = repo.GetCommitID()
+	} else {
+		commitID = "local-dir"
+	}
+
+	uniqueString := uuid.New()
+	runes := []rune(uniqueString.String())
+	branchName := source.GetName() + "-" + commitID + "-" + string(runes[0:5])
+	return strings.Replace(branchName, "\n", "", -1)
+}
+
+// generateDefaultCommitMsg constructs a default commit message based on the source information.
+func generateDefaultCommitMsg(source git.Source, serviceName string, from EnvLocale) string {
+	repo, ok := source.(git.Repo)
+	if ok {
+		commit := repo.GetCommitID()
+		return fmt.Sprintf("Promoting service %s at commit %s from branch %s in %s.", serviceName, commit, from.Branch, from.Path)
+	} else {
+		return fmt.Sprintf("Promoting service %s from local filesystem directory %s.", serviceName, from.Path)
+	}
+}
+
+func createPullRequest(ctx context.Context, from, to EnvLocale, newBranchName, commitMsg string, client *scm.Client) (*scm.PullRequest, error) {
+	prInput, err := makePullRequestInput(from, to, newBranchName, commitMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	u, _ := url.Parse(to.Path)
+	pathToUse := strings.TrimPrefix(strings.TrimSuffix(u.Path, ".git"), "/")
+	pr, _, err := client.PullRequests.Create(ctx, pathToUse, prInput)
+	return pr, err
+}

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -10,10 +10,10 @@ import (
 // TODO: OptionFunc for Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
-func makePullRequestInput(from, to EnvLocale, branchName, prBody string) (*scm.PullRequestInput, error) {
+func makePullRequestInput(from, to EnvLocation, branchName, prBody string) (*scm.PullRequestInput, error) {
 	var title string
 
-	_, toRepo, err := util.ExtractUserAndRepo(to.Path)
+	_, toRepo, err := util.ExtractUserAndRepo(to.RepoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,7 @@ func makePullRequestInput(from, to EnvLocale, branchName, prBody string) (*scm.P
 	if from.IsLocal() {
 		title = fmt.Sprintf("promotion from local filesystem directory to %s", toRepo)
 	} else {
-		_, fromRepo, err := util.ExtractUserAndRepo(from.Path)
+		_, fromRepo, err := util.ExtractUserAndRepo(from.RepoPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -10,18 +10,18 @@ import (
 // TODO: OptionFunc for Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
-func makePullRequestInput(fromLocal bool, fromURL, toURL, toBranch, branchName, prBody string) (*scm.PullRequestInput, error) {
+func makePullRequestInput(from, to EnvLocale, branchName, prBody string) (*scm.PullRequestInput, error) {
 	var title string
 
-	_, toRepo, err := util.ExtractUserAndRepo(toURL)
+	_, toRepo, err := util.ExtractUserAndRepo(to.Path)
 	if err != nil {
 		return nil, err
 	}
 
-	if fromLocal {
+	if from.IsLocal() {
 		title = fmt.Sprintf("promotion from local filesystem directory to %s", toRepo)
 	} else {
-		_, fromRepo, err := util.ExtractUserAndRepo(fromURL)
+		_, fromRepo, err := util.ExtractUserAndRepo(from.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -31,7 +31,7 @@ func makePullRequestInput(fromLocal bool, fromURL, toURL, toBranch, branchName, 
 	return &scm.PullRequestInput{
 		Title: title,
 		Head:  branchName,
-		Base:  toBranch,
+		Base:  to.Branch,
 		Body:  prBody,
 	}, nil
 }

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -7,10 +7,10 @@ import (
 	"github.com/rhd-gitops-example/services/pkg/util"
 )
 
-// TODO: OptionFuncs for Base and Title?
+// TODO: OptionFunc for Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
-func makePullRequestInput(fromLocal bool, fromURL, toURL, branchName, prBody string) (*scm.PullRequestInput, error) {
+func makePullRequestInput(fromLocal bool, fromURL, toURL, toBranch, branchName, prBody string) (*scm.PullRequestInput, error) {
 	var title string
 
 	_, toRepo, err := util.ExtractUserAndRepo(toURL)
@@ -31,7 +31,7 @@ func makePullRequestInput(fromLocal bool, fromURL, toURL, branchName, prBody str
 	return &scm.PullRequestInput{
 		Title: title,
 		Head:  branchName,
-		Base:  "master",
+		Base:  toBranch,
 		Body:  prBody,
 	}, nil
 }

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMakePullRequestInput(t *testing.T) {
-	pr, err := makePullRequestInput(false, "https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "my-test-branch", "foo bar wibble")
+	pr, err := makePullRequestInput(false, "https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "master", "my-test-branch", "foo bar wibble")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -9,7 +9,15 @@ import (
 )
 
 func TestMakePullRequestInput(t *testing.T) {
-	pr, err := makePullRequestInput(false, "https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "master", "my-test-branch", "foo bar wibble")
+	from := EnvLocale{
+		Path:   "https://example.com/project/dev-env.git",
+		Branch: "example",
+	}
+	to := EnvLocale{
+		Path:   "https://example.com/project/prod-env.git",
+		Branch: "master",
+	}
+	pr, err := makePullRequestInput(from, to, "my-test-branch", "foo bar wibble")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestMakePullRequestInput(t *testing.T) {
-	from := EnvLocale{
-		Path:   "https://example.com/project/dev-env.git",
-		Branch: "example",
+	from := EnvLocation{
+		RepoPath: "https://example.com/project/dev-env.git",
+		Branch:   "example",
 	}
-	to := EnvLocale{
-		Path:   "https://example.com/project/prod-env.git",
-		Branch: "master",
+	to := EnvLocation{
+		RepoPath: "https://example.com/project/prod-env.git",
+		Branch:   "master",
 	}
 	pr, err := makePullRequestInput(from, to, "my-test-branch", "foo bar wibble")
 	if err != nil {

--- a/pkg/promotion/service_manager.go
+++ b/pkg/promotion/service_manager.go
@@ -81,15 +81,12 @@ func WithRepoType(f string) serviceOpt {
 	}
 }
 
-// TODO: make this a command-line parameter defaulting to "master"
-const fromBranch = "master"
-
 // Promote is the main driver for promoting files between two
 // repositories.
 //
 // It uses a Git cache to checkout the code to, and will copy the environment
 // configuration for the `fromURL` to the `toURL` in a named branch.
-func (s *ServiceManager) Promote(serviceName, fromURL, toURL, newBranchName, message string, keepCache bool) error {
+func (s *ServiceManager) Promote(serviceName, fromURL, fromBranch, toURL, toBranch, newBranchName, message string, keepCache bool) error {
 	var source, destination git.Repo
 	var reposToDelete []git.Repo
 
@@ -189,7 +186,7 @@ func (s *ServiceManager) Promote(serviceName, fromURL, toURL, newBranchName, mes
 	}
 
 	ctx := context.Background()
-	pr, err := createPullRequest(ctx, fromURL, toURL, newBranchName, commitMsg, s.clientFactory(s.author.Token, toURL, s.repoType, s.tlsVerify), isLocal)
+	pr, err := createPullRequest(ctx, fromURL, toURL, toBranch, newBranchName, commitMsg, s.clientFactory(s.author.Token, toURL, s.repoType, s.tlsVerify), isLocal)
 	if err != nil {
 		message := fmt.Sprintf("failed to create a pull-request for branch %s, error: %s", newBranchName, err)
 		return git.GitError(message, toURL)
@@ -243,8 +240,8 @@ func (s *ServiceManager) cloneRepo(repoURL, branch string) (git.Repo, error) {
 	return repo, nil
 }
 
-func createPullRequest(ctx context.Context, fromURL, toURL, newBranchName, commitMsg string, client *scm.Client, fromLocal bool) (*scm.PullRequest, error) {
-	prInput, err := makePullRequestInput(fromLocal, fromURL, toURL, newBranchName, commitMsg)
+func createPullRequest(ctx context.Context, fromURL, toURL, toBranch, newBranchName, commitMsg string, client *scm.Client, fromLocal bool) (*scm.PullRequest, error) {
+	prInput, err := makePullRequestInput(fromLocal, fromURL, toURL, toBranch, newBranchName, commitMsg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/promotion/service_manager_test.go
+++ b/pkg/promotion/service_manager_test.go
@@ -63,7 +63,7 @@ func promoteWithSuccess(t *testing.T, keepCache bool, repoType string, tlsVerify
 	}
 	devRepo.AddFiles("services/my-service/base/config/myfile.yaml")
 	stagingRepo.AddFiles("")
-	err := sm.Promote("my-service", dev, staging, dstBranch, msg, keepCache)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, msg, keepCache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func promoteLocalWithSuccess(t *testing.T, keepCache bool, msg string) {
 	devRepo.AddFiles("config/myfile.yaml")
 	stagingRepo.AddFiles("staging")
 
-	err := sm.Promote("my-service", ldev, staging, dstBranch, msg, keepCache)
+	err := sm.Promote("my-service", ldev, "master", staging, "master", dstBranch, msg, keepCache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestPromoteLocalWithSuccessOneEnvAndIsUsed(t *testing.T) {
 	devRepo.AddFiles("/config/myfile.yaml")
 	stagingRepo.AddFiles("/staging")
 
-	err := sm.Promote("my-service", ldev, staging, dstBranch, "", false)
+	err := sm.Promote("my-service", ldev, "master", staging, "master", dstBranch, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestPromoteErrorsIfMultipleEnvironments(t *testing.T) {
 	devRepo.AddFiles("services/my-service/base/config/myfile.yaml")
 
 	msg := "foo message"
-	err := sm.Promote("my-service", dev, staging, dstBranch, msg, false)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, msg, false)
 	if err == nil {
 		t.Fail()
 	}
@@ -259,7 +259,7 @@ func TestPromoteWithCacheDeletionFailure(t *testing.T) {
 	devRepo.AddFiles("dev/services/my-service/base/config/myfile.yaml")
 	stagingRepo.AddFiles("staging")
 
-	err := sm.Promote("my-service", dev, staging, dstBranch, "", false)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func TestRepositoryCloneErrorOmitsToken(t *testing.T) {
 		errorMessage := fmt.Errorf("failed to clone repository %s: exit status 128", dev)
 		return nil, errorMessage
 	}
-	err := sm.Promote("my-service", dev, staging, dstBranch, "", false)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, "", false)
 	if err != nil {
 		devRepoToUseInError := fmt.Sprintf(".*%s", dev)
 		test.AssertErrorMatch(t, devRepoToUseInError, err)


### PR DESCRIPTION
These were previously hard-coded to "master", but it was straightforward to enable them as an option and it seems to work in my tests. (Speaking of tests, I wasn't sure how to test different branches in a unit test...)

I'm hoping that `EnvLocale` will help prevent too many extra parameters in the Promote function. Otherwise, this change would add 2 more, and specifying environments (#92) might add even more.

I may have gone a little bit over-zealous refactoring when putting in `EnvLocale`, so please let me know if I should scale that back.