### PR TITLE
[WIP] Consider subcommands for different promotion paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Usage:
   services promote [flags]
 
 Flags:
-      --branch-name string       the name of the branch on the destination repository for the pull request
+      --branch-name string       the name of the branch on the destination repository for the pull request (auto-generated if empty)
       --cache-dir string         where to cache Git checkouts (default "~/.promotion/cache")
       --commit-email string      the email to use for commits when creating branches
       --commit-message string    the msg to use on the resultant commit and pull request
@@ -85,6 +85,7 @@ Flags:
       --service string           service name to promote
       --to string                destination Git repository
       --to-branch string         branch on the destination Git repository (default "master")
+
 Global Flags:
       --github-token string   oauth access token to authenticate the request
 ```

--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ Flags:
       --commit-name string       the name to use for commits when creating branches
       --debug                    additional debug logging output
       --from string              source Git repository
+      --from-branch string       branch on the source Git repository (default "master")
   -h, --help                     help for promote
       --insecure-skip-verify     Insecure skip verify TLS certificate
       --keep-cache               whether to retain the locally cloned repositories in the cache directory
       --repository-type string   the type of repository: github, gitlab or ghe (default "github")
       --service string           service name to promote
       --to string                destination Git repository
-
+      --to-branch string         branch on the destination Git repository (default "master")
 Global Flags:
       --github-token string   oauth access token to authenticate the request
 ```
@@ -97,12 +98,14 @@ This will _copy_ all files under `/services/service-a/base/config/*` in `first-e
 - `--commit-name` : The other half of `commit-email`. Both must be set.
 - `--debug` : prints extra debug output if true.
 - `--from` : an https URL to a GitOps repository for 'remote' cases, or a path to a Git clone of a microservice for 'local' cases.
+- `--from-branch` : use this to specify a branch on the source repository, instead of using the "master" branch.
 - `--help`: prints the above text if true.
 - `--insecure-skip-verify` : skip TLS cerificate verification if true. Do not set this to true unless you know what you are doing.
 - `--keep-cache` : `cache-dir` is deleted unless this is set to true. Keeping the cache will often cause further promotion attempts to fail. This flag is mostly used along with `--debug` when investigating failure cases. 
 - `--repository-type` : the type of repository: github, gitlab or ghe (default "github"). If `--from` is a Git URL, it must be of the same type as that specified via `--to`.
 - `--service` : the destination path for promotion is `/environments/<env-name>/services/<service-name>/base/config/`. This argument defines `service-name` in that path.
 - `--to`: an https URL to the destination GitOps repository.
+- `--to-branch` : use this to specify a branch on the destination repository, instead of using the "master" branch.
 
 ### Troubleshooting
 

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -139,7 +139,6 @@ func promoteAction(c *cobra.Command, args []string) error {
 
 	// Optional flags
 	newBranchName := viper.GetString(branchNameFlag)
-	msg := viper.GetString(msgFlag)
 	debug := viper.GetBool(debugFlag)
 	fromBranch := viper.GetString(fromBranchFlag)
 	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
@@ -157,7 +156,18 @@ func promoteAction(c *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType)).Promote(service, fromRepo, fromBranch, toRepo, toBranch, newBranchName, msg, keepCache)
+
+	from := promotion.EnvLocale{
+		Path:   fromRepo,
+		Branch: fromBranch,
+	}
+	to := promotion.EnvLocale{
+		Path:   toRepo,
+		Branch: toBranch,
+	}
+
+	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/rhd-gitops-example/services/pkg/git"
@@ -13,136 +12,78 @@ import (
 	"github.com/tcnksm/go-gitconfig"
 )
 
-func makePromoteCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "promote",
-		Short: "promote from one environment to another",
-		RunE:  promoteAction,
-	}
+var promoteCmd = &cobra.Command{
+	Use:   "promote",
+	Short: "promote from one environment to another",
+	RunE:  promoteAction,
+}
+
+const (
+	fromFlag          = "from"
+	fromBranchFlag    = "from-branch"
+	fromEnvFolderFlag = "from-env-folder"
+	serviceFlag       = "service"
+	toFlag            = "to"
+	toBranchFlag      = "to-branch"
+	toEnvFolderFlag   = "to-env-folder"
+)
+
+func init() {
+	rootCmd.AddCommand(promoteCmd)
 
 	// Required flags
-	cmd.Flags().String(
+	promoteCmd.Flags().String(
 		fromFlag,
 		"",
 		"source Git repository",
 	)
-	logIfError(cmd.MarkFlagRequired(fromFlag))
-	logIfError(viper.BindPFlag(fromFlag, cmd.Flags().Lookup(fromFlag)))
+	logIfError(promoteCmd.MarkFlagRequired(fromFlag))
+	logIfError(viper.BindPFlag(fromFlag, promoteCmd.Flags().Lookup(fromFlag)))
 
-	cmd.Flags().String(
+	promoteCmd.Flags().String(
 		toFlag,
 		"",
 		"destination Git repository",
 	)
-	logIfError(cmd.MarkFlagRequired(toFlag))
-	logIfError(viper.BindPFlag(toFlag, cmd.Flags().Lookup(toFlag)))
+	logIfError(promoteCmd.MarkFlagRequired(toFlag))
+	logIfError(viper.BindPFlag(toFlag, promoteCmd.Flags().Lookup(toFlag)))
 
-	cmd.Flags().String(
+	promoteCmd.Flags().String(
 		serviceFlag,
 		"",
 		"service name to promote",
 	)
-	logIfError(cmd.MarkFlagRequired(serviceFlag))
-	logIfError(viper.BindPFlag(serviceFlag, cmd.Flags().Lookup(serviceFlag)))
+	logIfError(cobra.MarkFlagRequired(promoteCmd.Flags(), serviceFlag))
+	logIfError(viper.BindPFlag(serviceFlag, promoteCmd.Flags().Lookup(serviceFlag)))
 
 	// Optional flags
-	cmd.Flags().String(
-		branchNameFlag,
-		"",
-		"the name of the branch on the destination repository for the pull request (auto-generated if empty)",
-	)
-	logIfError(viper.BindPFlag(branchNameFlag, cmd.Flags().Lookup(branchNameFlag)))
-
-	cmd.Flags().String(
-		cacheDirFlag,
-		"~/.promotion/cache",
-		"where to cache Git checkouts",
-	)
-	logIfError(viper.BindPFlag(cacheDirFlag, cmd.Flags().Lookup(cacheDirFlag)))
-
-	cmd.Flags().String(
-		emailFlag,
-		"",
-		"the email to use for commits when creating branches",
-	)
-	logIfError(viper.BindPFlag(emailFlag, cmd.Flags().Lookup(emailFlag)))
-
-	cmd.Flags().String(
-		msgFlag,
-		"",
-		"the msg to use on the resultant commit and pull request",
-	)
-	logIfError(viper.BindPFlag(msgFlag, cmd.Flags().Lookup(msgFlag)))
-
-	cmd.Flags().String(
-		nameFlag,
-		"",
-		"the name to use for commits when creating branches",
-	)
-	logIfError(viper.BindPFlag(nameFlag, cmd.Flags().Lookup(nameFlag)))
-
-	cmd.Flags().Bool(
-		debugFlag,
-		false,
-		"additional debug logging output",
-	)
-	logIfError(viper.BindPFlag(debugFlag, cmd.Flags().Lookup(debugFlag)))
-
-	cmd.Flags().String(
+	promoteCmd.Flags().String(
 		fromBranchFlag,
 		"master",
 		"branch on the source Git repository",
 	)
-	logIfError(viper.BindPFlag(fromBranchFlag, cmd.Flags().Lookup(fromBranchFlag)))
+	logIfError(viper.BindPFlag(fromBranchFlag, promoteCmd.Flags().Lookup(fromBranchFlag)))
 
-	cmd.Flags().String(
+	promoteCmd.Flags().String(
 		fromEnvFolderFlag,
 		"",
 		"env folder on the source Git repository (if not provided, the repository should only have one environment)",
 	)
-	logIfError(viper.BindPFlag(fromEnvFolderFlag, cmd.Flags().Lookup(fromEnvFolderFlag)))
+	logIfError(viper.BindPFlag(fromEnvFolderFlag, promoteCmd.Flags().Lookup(fromEnvFolderFlag)))
 
-	cmd.Flags().Bool(
-		insecureSkipVerifyFlag,
-		false,
-		"Insecure skip verify TLS certificate",
-	)
-	logIfError(viper.BindPFlag(insecureSkipVerifyFlag, cmd.Flags().Lookup(insecureSkipVerifyFlag)))
-
-	cmd.Flags().Bool(
-		keepCacheFlag,
-		false,
-		"whether to retain the locally cloned repositories in the cache directory",
-	)
-	logIfError(viper.BindPFlag(keepCacheFlag, cmd.Flags().Lookup(keepCacheFlag)))
-
-	cmd.Flags().String(
-		repoTypeFlag,
-		"github",
-		"the type of repository: github, gitlab or ghe",
-	)
-	logIfError(viper.BindPFlag(repoTypeFlag, cmd.Flags().Lookup(repoTypeFlag)))
-
-	cmd.Flags().String(
+	promoteCmd.Flags().String(
 		toBranchFlag,
 		"master",
 		"branch on the destination Git repository",
 	)
-	logIfError(viper.BindPFlag(toBranchFlag, cmd.Flags().Lookup(toBranchFlag)))
+	logIfError(viper.BindPFlag(toBranchFlag, promoteCmd.Flags().Lookup(toBranchFlag)))
 
-	cmd.Flags().String(
+	promoteCmd.Flags().String(
 		toEnvFolderFlag,
 		"",
 		"env folder on the destination Git repository (if not provided, the repository should only have one environment)",
 	)
-	logIfError(viper.BindPFlag(toEnvFolderFlag, cmd.Flags().Lookup(toEnvFolderFlag)))
-	return cmd
-}
-
-func logIfError(e error) {
-	if e != nil {
-		log.Fatal(e)
-	}
+	logIfError(viper.BindPFlag(toEnvFolderFlag, promoteCmd.Flags().Lookup(toEnvFolderFlag)))
 }
 
 func promoteAction(c *cobra.Command, args []string) error {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -14,7 +14,8 @@ var promoteCmd = &cobra.Command{
 	Short: "promote from one environment to another",
 }
 
-// These flags are used in multiple subcommands
+// These flags are used in multiple subcommands, and must be defined as
+// persistent flags here in the parent command.
 const (
 	fromFlag    = "from"
 	serviceFlag = "service"
@@ -23,6 +24,30 @@ const (
 
 func init() {
 	rootCmd.AddCommand(promoteCmd)
+
+	promoteCmd.PersistentFlags().String(
+		fromFlag,
+		"",
+		"source Git repository / branch / environment folder",
+	)
+	logIfError(cobra.MarkFlagRequired(promoteCmd.PersistentFlags(), fromFlag))
+	logIfError(viper.BindPFlag(fromFlag, promoteCmd.PersistentFlags().Lookup(fromFlag)))
+
+	promoteCmd.PersistentFlags().String(
+		toFlag,
+		"",
+		"destination Git repository / branch / environment folder",
+	)
+	logIfError(cobra.MarkFlagRequired(promoteCmd.PersistentFlags(), toFlag))
+	logIfError(viper.BindPFlag(toFlag, promoteCmd.PersistentFlags().Lookup(toFlag)))
+
+	promoteCmd.PersistentFlags().String(
+		serviceFlag,
+		"",
+		"service name to promote",
+	)
+	logIfError(cobra.MarkFlagRequired(promoteCmd.PersistentFlags(), serviceFlag))
+	logIfError(viper.BindPFlag(serviceFlag, promoteCmd.PersistentFlags().Lookup(serviceFlag)))
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -95,6 +95,13 @@ func makePromoteCmd() *cobra.Command {
 	)
 	logIfError(viper.BindPFlag(fromBranchFlag, cmd.Flags().Lookup(fromBranchFlag)))
 
+	cmd.Flags().String(
+		fromEnvFolderFlag,
+		"",
+		"env folder on the source Git repository (if not provided, the repository should only have one environment)",
+	)
+	logIfError(viper.BindPFlag(fromEnvFolderFlag, cmd.Flags().Lookup(fromEnvFolderFlag)))
+
 	cmd.Flags().Bool(
 		insecureSkipVerifyFlag,
 		false,
@@ -122,6 +129,13 @@ func makePromoteCmd() *cobra.Command {
 		"branch on the destination Git repository",
 	)
 	logIfError(viper.BindPFlag(toBranchFlag, cmd.Flags().Lookup(toBranchFlag)))
+
+	cmd.Flags().String(
+		toEnvFolderFlag,
+		"",
+		"env folder on the destination Git repository (if not provided, the repository should only have one environment)",
+	)
+	logIfError(viper.BindPFlag(toEnvFolderFlag, cmd.Flags().Lookup(toEnvFolderFlag)))
 	return cmd
 }
 
@@ -142,10 +156,12 @@ func promoteAction(c *cobra.Command, args []string) error {
 	msg := viper.GetString(msgFlag)
 	debug := viper.GetBool(debugFlag)
 	fromBranch := viper.GetString(fromBranchFlag)
+	fromEnvFolder := viper.GetString(fromEnvFolderFlag)
 	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
 	keepCache := viper.GetBool(keepCacheFlag)
 	repoType := viper.GetString(repoTypeFlag)
 	toBranch := viper.GetString(toBranchFlag)
+	toEnvFolder := viper.GetString(toEnvFolderFlag)
 
 	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
 	if err != nil {
@@ -160,10 +176,12 @@ func promoteAction(c *cobra.Command, args []string) error {
 	from := promotion.EnvLocation{
 		RepoPath: fromRepo,
 		Branch:   fromBranch,
+		Folder:   fromEnvFolder,
 	}
 	to := promotion.EnvLocation{
 		RepoPath: toRepo,
 		Branch:   toBranch,
+		Folder:   toEnvFolder,
 	}
 
 	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -2,11 +2,8 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/rhd-gitops-example/services/pkg/git"
-	"github.com/rhd-gitops-example/services/pkg/promotion"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tcnksm/go-gitconfig"
@@ -15,118 +12,17 @@ import (
 var promoteCmd = &cobra.Command{
 	Use:   "promote",
 	Short: "promote from one environment to another",
-	RunE:  promoteAction,
 }
 
+// These flags are used in multiple subcommands
 const (
-	fromFlag          = "from"
-	fromBranchFlag    = "from-branch"
-	fromEnvFolderFlag = "from-env-folder"
-	serviceFlag       = "service"
-	toFlag            = "to"
-	toBranchFlag      = "to-branch"
-	toEnvFolderFlag   = "to-env-folder"
+	fromFlag    = "from"
+	serviceFlag = "service"
+	toFlag      = "to"
 )
 
 func init() {
 	rootCmd.AddCommand(promoteCmd)
-
-	// Required flags
-	promoteCmd.Flags().String(
-		fromFlag,
-		"",
-		"source Git repository",
-	)
-	logIfError(promoteCmd.MarkFlagRequired(fromFlag))
-	logIfError(viper.BindPFlag(fromFlag, promoteCmd.Flags().Lookup(fromFlag)))
-
-	promoteCmd.Flags().String(
-		toFlag,
-		"",
-		"destination Git repository",
-	)
-	logIfError(promoteCmd.MarkFlagRequired(toFlag))
-	logIfError(viper.BindPFlag(toFlag, promoteCmd.Flags().Lookup(toFlag)))
-
-	promoteCmd.Flags().String(
-		serviceFlag,
-		"",
-		"service name to promote",
-	)
-	logIfError(cobra.MarkFlagRequired(promoteCmd.Flags(), serviceFlag))
-	logIfError(viper.BindPFlag(serviceFlag, promoteCmd.Flags().Lookup(serviceFlag)))
-
-	// Optional flags
-	promoteCmd.Flags().String(
-		fromBranchFlag,
-		"master",
-		"branch on the source Git repository",
-	)
-	logIfError(viper.BindPFlag(fromBranchFlag, promoteCmd.Flags().Lookup(fromBranchFlag)))
-
-	promoteCmd.Flags().String(
-		fromEnvFolderFlag,
-		"",
-		"env folder on the source Git repository (if not provided, the repository should only have one environment)",
-	)
-	logIfError(viper.BindPFlag(fromEnvFolderFlag, promoteCmd.Flags().Lookup(fromEnvFolderFlag)))
-
-	promoteCmd.Flags().String(
-		toBranchFlag,
-		"master",
-		"branch on the destination Git repository",
-	)
-	logIfError(viper.BindPFlag(toBranchFlag, promoteCmd.Flags().Lookup(toBranchFlag)))
-
-	promoteCmd.Flags().String(
-		toEnvFolderFlag,
-		"",
-		"env folder on the destination Git repository (if not provided, the repository should only have one environment)",
-	)
-	logIfError(viper.BindPFlag(toEnvFolderFlag, promoteCmd.Flags().Lookup(toEnvFolderFlag)))
-}
-
-func promoteAction(c *cobra.Command, args []string) error {
-	// Required flags
-	fromRepo := viper.GetString(fromFlag)
-	toRepo := viper.GetString(toFlag)
-	service := viper.GetString(serviceFlag)
-
-	// Optional flags
-	newBranchName := viper.GetString(branchNameFlag)
-	msg := viper.GetString(msgFlag)
-	debug := viper.GetBool(debugFlag)
-	fromBranch := viper.GetString(fromBranchFlag)
-	fromEnvFolder := viper.GetString(fromEnvFolderFlag)
-	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
-	keepCache := viper.GetBool(keepCacheFlag)
-	repoType := viper.GetString(repoTypeFlag)
-	toBranch := viper.GetString(toBranchFlag)
-	toEnvFolder := viper.GetString(toEnvFolderFlag)
-
-	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
-	if err != nil {
-		return fmt.Errorf("failed to expand cacheDir path: %w", err)
-	}
-
-	author, err := newAuthor()
-	if err != nil {
-		return fmt.Errorf("unable to establish credentials: %w", err)
-	}
-
-	from := promotion.EnvLocation{
-		RepoPath: fromRepo,
-		Branch:   fromBranch,
-		Folder:   fromEnvFolder,
-	}
-	to := promotion.EnvLocation{
-		RepoPath: toRepo,
-		Branch:   toBranch,
-		Folder:   toEnvFolder,
-	}
-
-	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))
-	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -157,13 +157,13 @@ func promoteAction(c *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
 
-	from := promotion.EnvLocale{
-		Path:   fromRepo,
-		Branch: fromBranch,
+	from := promotion.EnvLocation{
+		RepoPath: fromRepo,
+		Branch:   fromBranch,
 	}
-	to := promotion.EnvLocale{
-		Path:   toRepo,
-		Branch: toBranch,
+	to := promotion.EnvLocation{
+		RepoPath: toRepo,
+		Branch:   toBranch,
 	}
 
 	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -88,6 +88,13 @@ func makePromoteCmd() *cobra.Command {
 	)
 	logIfError(viper.BindPFlag(debugFlag, cmd.Flags().Lookup(debugFlag)))
 
+	cmd.Flags().String(
+		fromBranchFlag,
+		"master",
+		"branch on the source Git repository",
+	)
+	logIfError(viper.BindPFlag(fromBranchFlag, cmd.Flags().Lookup(fromBranchFlag)))
+
 	cmd.Flags().Bool(
 		insecureSkipVerifyFlag,
 		false,
@@ -108,6 +115,13 @@ func makePromoteCmd() *cobra.Command {
 		"the type of repository: github, gitlab or ghe",
 	)
 	logIfError(viper.BindPFlag(repoTypeFlag, cmd.Flags().Lookup(repoTypeFlag)))
+
+	cmd.Flags().String(
+		toBranchFlag,
+		"master",
+		"branch on the source Git repository",
+	)
+	logIfError(viper.BindPFlag(toBranchFlag, cmd.Flags().Lookup(toBranchFlag)))
 	return cmd
 }
 
@@ -127,9 +141,12 @@ func promoteAction(c *cobra.Command, args []string) error {
 	newBranchName := viper.GetString(branchNameFlag)
 	msg := viper.GetString(msgFlag)
 	debug := viper.GetBool(debugFlag)
+	fromBranch := viper.GetString(fromBranchFlag)
 	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
 	keepCache := viper.GetBool(keepCacheFlag)
+	msg := viper.GetString(msgFlag)
 	repoType := viper.GetString(repoTypeFlag)
+	toBranch := viper.GetString(toBranchFlag)
 
 	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
 	if err != nil {
@@ -140,7 +157,7 @@ func promoteAction(c *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to establish credentials: %w", err)
 	}
-	return promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType)).Promote(service, fromRepo, toRepo, newBranchName, msg, keepCache)
+	return promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType)).Promote(service, fromRepo, fromBranch, toRepo, toBranch, newBranchName, msg, keepCache)
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -20,6 +20,7 @@ const (
 	fromFlag    = "from"
 	serviceFlag = "service"
 	toFlag      = "to"
+	repoFlag    = "repo"
 )
 
 func init() {
@@ -48,6 +49,13 @@ func init() {
 	)
 	logIfError(cobra.MarkFlagRequired(promoteCmd.PersistentFlags(), serviceFlag))
 	logIfError(viper.BindPFlag(serviceFlag, promoteCmd.PersistentFlags().Lookup(serviceFlag)))
+
+	promoteCmd.PersistentFlags().String(
+		repoFlag,
+		"",
+		"Git repository to work within",
+	)
+	logIfError(viper.BindPFlag(repoFlag, promoteCmd.PersistentFlags().Lookup(repoFlag)))
 }
 
 func newAuthor() (*git.Author, error) {

--- a/pkg/cmd/promote.go
+++ b/pkg/cmd/promote.go
@@ -119,7 +119,7 @@ func makePromoteCmd() *cobra.Command {
 	cmd.Flags().String(
 		toBranchFlag,
 		"master",
-		"branch on the source Git repository",
+		"branch on the destination Git repository",
 	)
 	logIfError(viper.BindPFlag(toBranchFlag, cmd.Flags().Lookup(toBranchFlag)))
 	return cmd
@@ -139,11 +139,11 @@ func promoteAction(c *cobra.Command, args []string) error {
 
 	// Optional flags
 	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
 	debug := viper.GetBool(debugFlag)
 	fromBranch := viper.GetString(fromBranchFlag)
 	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
 	keepCache := viper.GetBool(keepCacheFlag)
-	msg := viper.GetString(msgFlag)
 	repoType := viper.GetString(repoTypeFlag)
 	toBranch := viper.GetString(toBranchFlag)
 

--- a/pkg/cmd/promote_branch.go
+++ b/pkg/cmd/promote_branch.go
@@ -9,20 +9,20 @@ import (
 	"github.com/spf13/viper"
 )
 
-var promoteEnvCmd = &cobra.Command{
-	Use:   "env",
-	Short: "promote from one environment folder to another in the same repository",
-	RunE:  promoteEnvAction,
+var promoteBranchCmd = &cobra.Command{
+	Use:   "branch",
+	Short: "promote between branches with only one environment folder in the same repository",
+	RunE:  promoteBranchAction,
 }
 
 func init() {
-	promoteCmd.AddCommand(promoteEnvCmd)
+	promoteCmd.AddCommand(promoteBranchCmd)
 }
 
-func promoteEnvAction(c *cobra.Command, args []string) error {
+func promoteBranchAction(c *cobra.Command, args []string) error {
 	// Required flags
-	fromEnvFolder := viper.GetString(fromFlag)
-	toEnvFolder := viper.GetString(toFlag)
+	fromBranch := viper.GetString(fromFlag)
+	toBranch := viper.GetString(toFlag)
 	service := viper.GetString(serviceFlag)
 	repo := viper.GetString(repoFlag)
 
@@ -46,13 +46,13 @@ func promoteEnvAction(c *cobra.Command, args []string) error {
 
 	from := promotion.EnvLocation{
 		RepoPath: repo,
-		Branch:   "master",
-		Folder:   fromEnvFolder,
+		Branch:   fromBranch,
+		Folder:   "",
 	}
 	to := promotion.EnvLocation{
 		RepoPath: repo,
-		Branch:   "master",
-		Folder:   toEnvFolder,
+		Branch:   toBranch,
+		Folder:   "",
 	}
 
 	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))

--- a/pkg/cmd/promote_classic.go
+++ b/pkg/cmd/promote_classic.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/rhd-gitops-example/services/pkg/promotion"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var promoteComplexCmd = &cobra.Command{
+	Use:   "complex",
+	Short: "promote arbitrarily from one repo/branch/folder to another",
+	RunE:  promoteComplexAction,
+}
+
+const (
+	fromBranchFlag    = "from-branch"
+	fromEnvFolderFlag = "from-env-folder"
+	toBranchFlag      = "to-branch"
+	toEnvFolderFlag   = "to-env-folder"
+)
+
+func init() {
+	promoteCmd.AddCommand(promoteComplexCmd)
+
+	// Required flags
+	promoteComplexCmd.Flags().String(
+		fromFlag,
+		"",
+		"source Git repository",
+	)
+	logIfError(promoteComplexCmd.MarkFlagRequired(fromFlag))
+	logIfError(viper.BindPFlag(fromFlag, promoteComplexCmd.Flags().Lookup(fromFlag)))
+
+	promoteComplexCmd.Flags().String(
+		toFlag,
+		"",
+		"destination Git repository",
+	)
+	logIfError(promoteComplexCmd.MarkFlagRequired(toFlag))
+	logIfError(viper.BindPFlag(toFlag, promoteComplexCmd.Flags().Lookup(toFlag)))
+
+	promoteComplexCmd.Flags().String(
+		serviceFlag,
+		"",
+		"service name to promote",
+	)
+	logIfError(cobra.MarkFlagRequired(promoteComplexCmd.Flags(), serviceFlag))
+	logIfError(viper.BindPFlag(serviceFlag, promoteComplexCmd.Flags().Lookup(serviceFlag)))
+
+	// Optional flags
+	promoteComplexCmd.Flags().String(
+		fromBranchFlag,
+		"master",
+		"branch on the source Git repository",
+	)
+	logIfError(viper.BindPFlag(fromBranchFlag, promoteComplexCmd.Flags().Lookup(fromBranchFlag)))
+
+	promoteComplexCmd.Flags().String(
+		fromEnvFolderFlag,
+		"",
+		"env folder on the source Git repository (if not provided, the repository should only have one environment)",
+	)
+	logIfError(viper.BindPFlag(fromEnvFolderFlag, promoteComplexCmd.Flags().Lookup(fromEnvFolderFlag)))
+
+	promoteComplexCmd.Flags().String(
+		toBranchFlag,
+		"master",
+		"branch on the destination Git repository",
+	)
+	logIfError(viper.BindPFlag(toBranchFlag, promoteComplexCmd.Flags().Lookup(toBranchFlag)))
+
+	promoteComplexCmd.Flags().String(
+		toEnvFolderFlag,
+		"",
+		"env folder on the destination Git repository (if not provided, the repository should only have one environment)",
+	)
+	logIfError(viper.BindPFlag(toEnvFolderFlag, promoteComplexCmd.Flags().Lookup(toEnvFolderFlag)))
+}
+
+func promoteComplexAction(c *cobra.Command, args []string) error {
+	// Required flags
+	fromRepo := viper.GetString(fromFlag)
+	toRepo := viper.GetString(toFlag)
+	service := viper.GetString(serviceFlag)
+
+	// Optional flags
+	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
+	debug := viper.GetBool(debugFlag)
+	fromBranch := viper.GetString(fromBranchFlag)
+	fromEnvFolder := viper.GetString(fromEnvFolderFlag)
+	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
+	keepCache := viper.GetBool(keepCacheFlag)
+	repoType := viper.GetString(repoTypeFlag)
+	toBranch := viper.GetString(toBranchFlag)
+	toEnvFolder := viper.GetString(toEnvFolderFlag)
+
+	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
+	if err != nil {
+		return fmt.Errorf("failed to expand cacheDir path: %w", err)
+	}
+
+	author, err := newAuthor()
+	if err != nil {
+		return fmt.Errorf("unable to establish credentials: %w", err)
+	}
+
+	from := promotion.EnvLocation{
+		RepoPath: fromRepo,
+		Branch:   fromBranch,
+		Folder:   fromEnvFolder,
+	}
+	to := promotion.EnvLocation{
+		RepoPath: toRepo,
+		Branch:   toBranch,
+		Folder:   toEnvFolder,
+	}
+
+	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
+}

--- a/pkg/cmd/promote_classic.go
+++ b/pkg/cmd/promote_classic.go
@@ -25,31 +25,6 @@ const (
 func init() {
 	promoteCmd.AddCommand(promoteComplexCmd)
 
-	// Required flags
-	promoteComplexCmd.Flags().String(
-		fromFlag,
-		"",
-		"source Git repository",
-	)
-	logIfError(promoteComplexCmd.MarkFlagRequired(fromFlag))
-	logIfError(viper.BindPFlag(fromFlag, promoteComplexCmd.Flags().Lookup(fromFlag)))
-
-	promoteComplexCmd.Flags().String(
-		toFlag,
-		"",
-		"destination Git repository",
-	)
-	logIfError(promoteComplexCmd.MarkFlagRequired(toFlag))
-	logIfError(viper.BindPFlag(toFlag, promoteComplexCmd.Flags().Lookup(toFlag)))
-
-	promoteComplexCmd.Flags().String(
-		serviceFlag,
-		"",
-		"service name to promote",
-	)
-	logIfError(cobra.MarkFlagRequired(promoteComplexCmd.Flags(), serviceFlag))
-	logIfError(viper.BindPFlag(serviceFlag, promoteComplexCmd.Flags().Lookup(serviceFlag)))
-
 	// Optional flags
 	promoteComplexCmd.Flags().String(
 		fromBranchFlag,

--- a/pkg/cmd/promote_env.go
+++ b/pkg/cmd/promote_env.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/rhd-gitops-example/services/pkg/promotion"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var promoteEnvCmd = &cobra.Command{
+	Use:   "env",
+	Short: "promote from one environment folder to another in the same repository",
+	RunE:  promoteEnvAction,
+}
+
+const (
+	repoFlag = "repo"
+)
+
+func init() {
+	promoteCmd.AddCommand(promoteEnvCmd)
+
+	promoteEnvCmd.Flags().String(
+		repoFlag,
+		"",
+		"Git repository to work within",
+	)
+	logIfError(cobra.MarkFlagRequired(promoteEnvCmd.Flags(), repoFlag))
+	logIfError(viper.BindPFlag(repoFlag, promoteEnvCmd.Flags().Lookup(repoFlag)))
+}
+
+func promoteEnvAction(c *cobra.Command, args []string) error {
+	// Required flags
+	fromEnvFolder := viper.GetString(fromFlag)
+	toEnvFolder := viper.GetString(toFlag)
+	service := viper.GetString(serviceFlag)
+	repo := viper.GetString(repoFlag)
+
+	// Optional flags
+	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
+	debug := viper.GetBool(debugFlag)
+	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
+	keepCache := viper.GetBool(keepCacheFlag)
+	repoType := viper.GetString(repoTypeFlag)
+
+	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
+	if err != nil {
+		return fmt.Errorf("failed to expand cacheDir path: %w", err)
+	}
+
+	author, err := newAuthor()
+	if err != nil {
+		return fmt.Errorf("unable to establish credentials: %w", err)
+	}
+
+	from := promotion.EnvLocation{
+		RepoPath: repo,
+		Branch:   "master",
+		Folder:   fromEnvFolder,
+	}
+	to := promotion.EnvLocation{
+		RepoPath: repo,
+		Branch:   "master",
+		Folder:   toEnvFolder,
+	}
+
+	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
+}

--- a/pkg/cmd/promote_repo.go
+++ b/pkg/cmd/promote_repo.go
@@ -17,31 +17,6 @@ var promoteRepoCmd = &cobra.Command{
 
 func init() {
 	promoteCmd.AddCommand(promoteRepoCmd)
-
-	// Required flags
-	promoteRepoCmd.Flags().String(
-		fromFlag,
-		"",
-		"source Git repository",
-	)
-	logIfError(promoteRepoCmd.MarkFlagRequired(fromFlag))
-	logIfError(viper.BindPFlag(fromFlag, promoteRepoCmd.Flags().Lookup(fromFlag)))
-
-	promoteRepoCmd.Flags().String(
-		toFlag,
-		"",
-		"destination Git repository",
-	)
-	logIfError(promoteRepoCmd.MarkFlagRequired(toFlag))
-	logIfError(viper.BindPFlag(toFlag, promoteRepoCmd.Flags().Lookup(toFlag)))
-
-	promoteRepoCmd.Flags().String(
-		serviceFlag,
-		"",
-		"service name to promote",
-	)
-	logIfError(cobra.MarkFlagRequired(promoteRepoCmd.Flags(), serviceFlag))
-	logIfError(viper.BindPFlag(serviceFlag, promoteRepoCmd.Flags().Lookup(serviceFlag)))
 }
 
 func promoteRepoAction(c *cobra.Command, args []string) error {

--- a/pkg/cmd/promote_repo.go
+++ b/pkg/cmd/promote_repo.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/rhd-gitops-example/services/pkg/promotion"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var promoteRepoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "promote from a repository with one environment folder to another",
+	RunE:  promoteRepoAction,
+}
+
+func init() {
+	promoteCmd.AddCommand(promoteRepoCmd)
+
+	// Required flags
+	promoteRepoCmd.Flags().String(
+		fromFlag,
+		"",
+		"source Git repository",
+	)
+	logIfError(promoteRepoCmd.MarkFlagRequired(fromFlag))
+	logIfError(viper.BindPFlag(fromFlag, promoteRepoCmd.Flags().Lookup(fromFlag)))
+
+	promoteRepoCmd.Flags().String(
+		toFlag,
+		"",
+		"destination Git repository",
+	)
+	logIfError(promoteRepoCmd.MarkFlagRequired(toFlag))
+	logIfError(viper.BindPFlag(toFlag, promoteRepoCmd.Flags().Lookup(toFlag)))
+
+	promoteRepoCmd.Flags().String(
+		serviceFlag,
+		"",
+		"service name to promote",
+	)
+	logIfError(cobra.MarkFlagRequired(promoteRepoCmd.Flags(), serviceFlag))
+	logIfError(viper.BindPFlag(serviceFlag, promoteRepoCmd.Flags().Lookup(serviceFlag)))
+}
+
+func promoteRepoAction(c *cobra.Command, args []string) error {
+	// Required flags
+	fromRepo := viper.GetString(fromFlag)
+	toRepo := viper.GetString(toFlag)
+	service := viper.GetString(serviceFlag)
+
+	// Optional flags
+	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
+	debug := viper.GetBool(debugFlag)
+	insecureSkipVerify := viper.GetBool(insecureSkipVerifyFlag)
+	keepCache := viper.GetBool(keepCacheFlag)
+	repoType := viper.GetString(repoTypeFlag)
+
+	cacheDir, err := homedir.Expand(viper.GetString(cacheDirFlag))
+	if err != nil {
+		return fmt.Errorf("failed to expand cacheDir path: %w", err)
+	}
+
+	author, err := newAuthor()
+	if err != nil {
+		return fmt.Errorf("unable to establish credentials: %w", err)
+	}
+
+	from := promotion.EnvLocation{
+		RepoPath: fromRepo,
+		Branch:   "master",
+		Folder:   "",
+	}
+	to := promotion.EnvLocation{
+		RepoPath: toRepo,
+		Branch:   "master",
+		Folder:   "",
+	}
+
+	sm := promotion.New(cacheDir, author, promotion.WithDebug(debug), promotion.WithInsecureSkipVerify(insecureSkipVerify), promotion.WithRepoType(repoType))
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -23,6 +23,8 @@ const (
 	insecureSkipVerifyFlag = "insecure-skip-verify"
 	debugFlag              = "debug"
 	keepCacheFlag          = "keep-cache"
+	fromBranchFlag         = "from-branch"
+	toBranchFlag           = "to-branch"
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -10,21 +10,21 @@ import (
 )
 
 const (
-	githubTokenFlag        = "github-token"
 	branchNameFlag         = "branch-name"
-	fromFlag               = "from"
-	toFlag                 = "to"
-	serviceFlag            = "service"
-	repoTypeFlag           = "repository-type"
 	cacheDirFlag           = "cache-dir"
+	emailFlag              = "commit-email"
 	msgFlag                = "commit-message"
 	nameFlag               = "commit-name"
-	emailFlag              = "commit-email"
-	insecureSkipVerifyFlag = "insecure-skip-verify"
 	debugFlag              = "debug"
-	keepCacheFlag          = "keep-cache"
+	fromFlag               = "from"
 	fromBranchFlag         = "from-branch"
+	insecureSkipVerifyFlag = "insecure-skip-verify"
+	keepCacheFlag          = "keep-cache"
+	repoTypeFlag           = "repository-type"
+	serviceFlag            = "service"
+	toFlag                 = "to"
 	toBranchFlag           = "to-branch"
+	githubTokenFlag        = "github-token"
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -18,12 +18,14 @@ const (
 	debugFlag              = "debug"
 	fromFlag               = "from"
 	fromBranchFlag         = "from-branch"
+	fromEnvFolderFlag      = "from-env-folder"
 	insecureSkipVerifyFlag = "insecure-skip-verify"
 	keepCacheFlag          = "keep-cache"
 	repoTypeFlag           = "repository-type"
 	serviceFlag            = "service"
 	toFlag                 = "to"
 	toBranchFlag           = "to-branch"
+	toEnvFolderFlag        = "to-env-folder"
 	githubTokenFlag        = "github-token"
 )
 

--- a/pkg/git/mock/file_info.go
+++ b/pkg/git/mock/file_info.go
@@ -1,0 +1,39 @@
+package mock
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type mockFileInfo struct {
+	name string
+}
+
+func newFileInfo(name string) mockFileInfo {
+	return mockFileInfo{name}
+}
+
+func (f mockFileInfo) Name() string {
+	return filepath.Base(f.name)
+}
+
+func (f mockFileInfo) Size() int64 {
+	return 8
+}
+
+func (f mockFileInfo) Mode() os.FileMode {
+	return os.ModeDir
+}
+
+func (f mockFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (f mockFileInfo) IsDir() bool {
+	return true
+}
+
+func (f mockFileInfo) Sys() interface{} {
+	return nil
+}

--- a/pkg/git/mock/mock.go
+++ b/pkg/git/mock/mock.go
@@ -97,7 +97,7 @@ func (m *Repository) Commit(msg string, author *git.Author) error {
 }
 
 func (m *Repository) DirectoriesUnderPath(path string) ([]os.FileInfo, error) {
-	dirs := make([]os.FileInfo, len(m.files), len(m.files))
+	dirs := make([]os.FileInfo, len(m.files))
 	for i, f := range m.files {
 		dirs[i] = newFileInfo(f)
 	}

--- a/pkg/git/mock/mock.go
+++ b/pkg/git/mock/mock.go
@@ -96,9 +96,12 @@ func (m *Repository) Commit(msg string, author *git.Author) error {
 	return m.CommitErr
 }
 
-// Not implemented
 func (m *Repository) DirectoriesUnderPath(path string) ([]os.FileInfo, error) {
-	return nil, nil
+	dirs := make([]os.FileInfo, len(m.files), len(m.files))
+	for i, f := range m.files {
+		dirs[i] = newFileInfo(f)
+	}
+	return dirs, nil
 }
 
 func (m *Repository) GetUniqueEnvironmentFolder() (string, error) {

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -102,15 +102,13 @@ func (r *Repository) WriteFile(src io.Reader, dst string) error {
 // Returns an error if there was a problem in doing so (including if more than one folder found)
 // string return type for ease of mocking, callers would use .Name() anyway
 func (r *Repository) GetUniqueEnvironmentFolder() (string, error) {
-	lookup := filepath.Join(r.repoPath(), "environments")
-
-	foundDirsUnderEnv, err := r.DirectoriesUnderPath(lookup)
+	foundDirsUnderEnv, err := r.DirectoriesUnderPath("environments")
 	if err != nil {
 		return "", err
 	}
 	numDirsUnderEnv := len(foundDirsUnderEnv)
 	if numDirsUnderEnv != 1 {
-		return "", fmt.Errorf("found %d directories under environments folder, wanted one. Looked under directory %s", numDirsUnderEnv, lookup)
+		return "", fmt.Errorf("found %d directories under environments folder, wanted one", numDirsUnderEnv)
 	}
 	foundEnvDir := foundDirsUnderEnv[0]
 	return foundEnvDir.Name(), nil
@@ -119,7 +117,8 @@ func (r *Repository) GetUniqueEnvironmentFolder() (string, error) {
 // Returns the directory names of those under a certain path (excluding sub-dirs)
 // Returns an error if a directory list attempt errored
 func (r *Repository) DirectoriesUnderPath(path string) ([]os.FileInfo, error) {
-	files, err := ioutil.ReadDir(path)
+	lookup := filepath.Join(r.repoPath(), path)
+	files, err := ioutil.ReadDir(lookup)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/promotion/promote.go
+++ b/pkg/promotion/promote.go
@@ -1,0 +1,160 @@
+package promotion
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/rhd-gitops-example/services/pkg/git"
+	"github.com/rhd-gitops-example/services/pkg/local"
+
+	"github.com/google/uuid"
+	"github.com/jenkins-x/go-scm/scm"
+)
+
+type EnvLocale struct {
+	Path   string // URL or local path
+	Branch string
+}
+
+func (env EnvLocale) IsLocal() bool {
+	parsed, err := url.Parse(env.Path)
+	if err != nil {
+		log.Printf("Error while parsing URL for environment path: '%v', assuming it is local.\n", err)
+		return true
+	}
+	return parsed.Scheme == ""
+}
+
+// Promote is the main driver for promoting files between two
+// repositories.
+//
+// It uses a Git cache to checkout the code to, and will copy the environment
+// configuration for the `fromURL` to the `toURL` in a named branch.
+func (s *ServiceManager) Promote(serviceName string, from, to EnvLocale, newBranchName, message string, keepCache bool) error {
+	var reposToDelete []git.Repo
+	if !keepCache {
+		defer clearCache(&reposToDelete)
+	}
+
+	var source git.Source
+	var err error
+	if from.IsLocal() {
+		source = s.localFactory(from.Path, s.debug)
+	} else {
+		source, err = s.checkoutSourceRepo(from.Path, from.Branch)
+		if err != nil {
+			return git.GitError("error checking out source repository from Git", from.Path)
+		}
+		reposToDelete = append(reposToDelete, source.(git.Repo))
+	}
+	if newBranchName == "" {
+		newBranchName = generateBranchName(source)
+	}
+
+	destination, err := s.checkoutDestinationRepo(to.Path, newBranchName)
+	if err != nil {
+		return err
+	}
+	reposToDelete = append(reposToDelete, destination)
+	destinationEnvironment, err := destination.GetUniqueEnvironmentFolder()
+	if err != nil {
+		return fmt.Errorf("could not determine unique environment name for destination repository - check that only one directory exists under it and you can write to your cache folder")
+	}
+
+	var copied []string
+	if from.IsLocal() {
+		copied, err = local.CopyConfig(serviceName, source, destination, destinationEnvironment)
+		if err != nil {
+			return fmt.Errorf("failed to set up local repository: %w", err)
+		}
+	} else {
+		repo, ok := source.(git.Repo)
+		if !ok {
+			// should not happen, but just in case
+			return fmt.Errorf("failed to convert source '%v' to Git Repo", source)
+		}
+		sourceEnvironment, err := repo.GetUniqueEnvironmentFolder()
+		if err != nil {
+			return fmt.Errorf("could not determine unique environment name for source repository - check that only one directory exists under it and you can write to your cache folder")
+		}
+
+		copied, err = git.CopyService(serviceName, source, destination, sourceEnvironment, destinationEnvironment)
+		if err != nil {
+			return fmt.Errorf("failed to copy service: %w", err)
+		}
+	}
+
+	if message == "" {
+		message = generateDefaultCommitMsg(source, serviceName, from)
+	}
+	if err := destination.StageFiles(copied...); err != nil {
+		return fmt.Errorf("failed to stage files %s: %w", copied, err)
+	}
+	if err := destination.Commit(message, s.author); err != nil {
+		return fmt.Errorf("failed to commit: %w", err)
+	}
+	if err := destination.Push(newBranchName); err != nil {
+		return fmt.Errorf("failed to push to Git repository - check the access token is correct with sufficient permissions: %w", err)
+	}
+
+	ctx := context.Background()
+	pr, err := createPullRequest(ctx, from, to, newBranchName, message, s.clientFactory(s.author.Token, to.Path, s.repoType, s.tlsVerify))
+	if err != nil {
+		message := fmt.Sprintf("failed to create a pull-request for branch %s, error: %s", newBranchName, err)
+		return git.GitError(message, to.Path)
+	}
+	log.Printf("created PR %d", pr.Number)
+	return nil
+}
+
+func clearCache(repos *[]git.Repo) {
+	for _, repo := range *repos {
+		err := repo.DeleteCache()
+		if err != nil {
+			log.Printf("failed deleting files from cache: %s", err)
+		}
+	}
+}
+
+// generateBranchName constructs a branch name based on the source (a commit or local) and
+// a random UUID
+func generateBranchName(source git.Source) string {
+	var commitID string
+	repo, ok := source.(git.Repo)
+	if ok {
+		commitID = repo.GetCommitID()
+	} else {
+		commitID = "local-dir"
+	}
+
+	uniqueString := uuid.New()
+	runes := []rune(uniqueString.String())
+	branchName := source.GetName() + "-" + commitID + "-" + string(runes[0:5])
+	return strings.Replace(branchName, "\n", "", -1)
+}
+
+// generateDefaultCommitMsg constructs a default commit message based on the source information.
+func generateDefaultCommitMsg(source git.Source, serviceName string, from EnvLocale) string {
+	repo, ok := source.(git.Repo)
+	if ok {
+		commit := repo.GetCommitID()
+		return fmt.Sprintf("Promoting service %s at commit %s from branch %s in %s.", serviceName, commit, from.Branch, from.Path)
+	} else {
+		return fmt.Sprintf("Promoting service %s from local filesystem directory %s.", serviceName, from.Path)
+	}
+}
+
+func createPullRequest(ctx context.Context, from, to EnvLocale, newBranchName, commitMsg string, client *scm.Client) (*scm.PullRequest, error) {
+	prInput, err := makePullRequestInput(from, to, newBranchName, commitMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	u, _ := url.Parse(to.Path)
+	pathToUse := strings.TrimPrefix(strings.TrimSuffix(u.Path, ".git"), "/")
+	pr, _, err := client.PullRequests.Create(ctx, pathToUse, prInput)
+	return pr, err
+}

--- a/pkg/promotion/promote.go
+++ b/pkg/promotion/promote.go
@@ -158,3 +158,24 @@ func createPullRequest(ctx context.Context, from, to EnvLocation, newBranchName,
 	pr, _, err := client.PullRequests.Create(ctx, pathToUse, prInput)
 	return pr, err
 }
+
+func getEnvironmentFolder(r git.Repo, folder string) (string, error) {
+	if folder == "" { // folder not specified, require that there is only one
+		dir, err := r.GetUniqueEnvironmentFolder()
+		if err != nil {
+			return "", fmt.Errorf("could not determine unique environment name for source repository - check that only one directory exists under it and you can write to your cache folder")
+		}
+		return dir, nil
+	}
+
+	dirs, err := r.DirectoriesUnderPath("environments")
+	if err != nil {
+		return "", err
+	}
+	for _, dir := range dirs {
+		if dir.Name() == folder {
+			return dir.Name(), nil
+		}
+	}
+	return "", fmt.Errorf("did not find environment folder matching '%v', only found '%v'", folder, dirs)
+}

--- a/pkg/promotion/promote.go
+++ b/pkg/promotion/promote.go
@@ -17,6 +17,7 @@ import (
 type EnvLocation struct {
 	RepoPath string // URL or local path
 	Branch   string
+	Folder   string
 }
 
 func (env EnvLocation) IsLocal() bool {
@@ -59,9 +60,9 @@ func (s *ServiceManager) Promote(serviceName string, from, to EnvLocation, newBr
 		return err
 	}
 	reposToDelete = append(reposToDelete, destination)
-	destinationEnvironment, err := destination.GetUniqueEnvironmentFolder()
+	destinationEnvironment, err := getEnvironmentFolder(destination, to.Folder)
 	if err != nil {
-		return fmt.Errorf("could not determine unique environment name for destination repository - check that only one directory exists under it and you can write to your cache folder")
+		return err
 	}
 
 	var copied []string
@@ -76,9 +77,9 @@ func (s *ServiceManager) Promote(serviceName string, from, to EnvLocation, newBr
 			// should not happen, but just in case
 			return fmt.Errorf("failed to convert source '%v' to Git Repo", source)
 		}
-		sourceEnvironment, err := repo.GetUniqueEnvironmentFolder()
+		sourceEnvironment, err := getEnvironmentFolder(repo, from.Folder)
 		if err != nil {
-			return fmt.Errorf("could not determine unique environment name for source repository - check that only one directory exists under it and you can write to your cache folder")
+			return err
 		}
 
 		copied, err = git.CopyService(serviceName, source, destination, sourceEnvironment, destinationEnvironment)

--- a/pkg/promotion/promote_test.go
+++ b/pkg/promotion/promote_test.go
@@ -1,0 +1,45 @@
+package promotion
+
+import (
+	"testing"
+
+	"github.com/rhd-gitops-example/services/pkg/git"
+	"github.com/rhd-gitops-example/services/pkg/git/mock"
+)
+
+func TestGetEnvironmentFolder(t *testing.T) {
+	noFolders := mock.New("nonePath", "master")
+	oneFolder := mock.New("oenPath", "master")
+	oneFolder.AddFiles("example")
+	twoFolders := mock.New("twoPath", "master")
+	twoFolders.AddFiles("example")
+	twoFolders.AddFiles("another")
+
+	tests := []struct {
+		repo           git.Repo
+		checkFolder    string
+		expectedFolder string
+		expectedError  bool
+	}{
+		{noFolders, "", "", true},
+		{noFolders, "example", "", true},
+		{oneFolder, "", "example", false},
+		{oneFolder, "example", "example", false},
+		{oneFolder, "another", "", true},
+		{twoFolders, "", "", true},
+		{twoFolders, "example", "example", false},
+		{twoFolders, "another", "another", false},
+	}
+
+	for _, test := range tests {
+		f, err := getEnvironmentFolder(test.repo, test.checkFolder)
+		if test.expectedError && err == nil {
+			t.Errorf("getEnvironmentFolder(%+v, '%v') gave nil err, but we wanted an error.", test.repo, test.checkFolder)
+		} else if !test.expectedError && err != nil {
+			t.Errorf("getEnvironmentFolder(%+v, '%v') gave error '%v', but we wanted no error.", test.repo, test.checkFolder, err)
+		}
+		if f != test.expectedFolder {
+			t.Errorf("getEnvironmentFolder(%+v, '%v') gave folder '%v', but we wanted '%v'.", test.repo, test.checkFolder, f, test.expectedFolder)
+		}
+	}
+}

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -10,10 +10,10 @@ import (
 // TODO: OptionFunc for Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
-func makePullRequestInput(from, to EnvLocale, branchName, prBody string) (*scm.PullRequestInput, error) {
+func makePullRequestInput(from, to EnvLocation, branchName, prBody string) (*scm.PullRequestInput, error) {
 	var title string
 
-	_, toRepo, err := util.ExtractUserAndRepo(to.Path)
+	_, toRepo, err := util.ExtractUserAndRepo(to.RepoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,7 @@ func makePullRequestInput(from, to EnvLocale, branchName, prBody string) (*scm.P
 	if from.IsLocal() {
 		title = fmt.Sprintf("promotion from local filesystem directory to %s", toRepo)
 	} else {
-		_, fromRepo, err := util.ExtractUserAndRepo(from.Path)
+		_, fromRepo, err := util.ExtractUserAndRepo(from.RepoPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -10,18 +10,18 @@ import (
 // TODO: OptionFunc for Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
-func makePullRequestInput(fromLocal bool, fromURL, toURL, toBranch, branchName, prBody string) (*scm.PullRequestInput, error) {
+func makePullRequestInput(from, to EnvLocale, branchName, prBody string) (*scm.PullRequestInput, error) {
 	var title string
 
-	_, toRepo, err := util.ExtractUserAndRepo(toURL)
+	_, toRepo, err := util.ExtractUserAndRepo(to.Path)
 	if err != nil {
 		return nil, err
 	}
 
-	if fromLocal {
+	if from.IsLocal() {
 		title = fmt.Sprintf("promotion from local filesystem directory to %s", toRepo)
 	} else {
-		_, fromRepo, err := util.ExtractUserAndRepo(fromURL)
+		_, fromRepo, err := util.ExtractUserAndRepo(from.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -31,7 +31,7 @@ func makePullRequestInput(fromLocal bool, fromURL, toURL, toBranch, branchName, 
 	return &scm.PullRequestInput{
 		Title: title,
 		Head:  branchName,
-		Base:  toBranch,
+		Base:  to.Branch,
 		Body:  prBody,
 	}, nil
 }

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -7,10 +7,10 @@ import (
 	"github.com/rhd-gitops-example/services/pkg/util"
 )
 
-// TODO: OptionFuncs for Base and Title?
+// TODO: OptionFunc for Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
-func makePullRequestInput(fromLocal bool, fromURL, toURL, branchName, prBody string) (*scm.PullRequestInput, error) {
+func makePullRequestInput(fromLocal bool, fromURL, toURL, toBranch, branchName, prBody string) (*scm.PullRequestInput, error) {
 	var title string
 
 	_, toRepo, err := util.ExtractUserAndRepo(toURL)
@@ -31,7 +31,7 @@ func makePullRequestInput(fromLocal bool, fromURL, toURL, branchName, prBody str
 	return &scm.PullRequestInput{
 		Title: title,
 		Head:  branchName,
-		Base:  "master",
+		Base:  toBranch,
 		Body:  prBody,
 	}, nil
 }

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMakePullRequestInput(t *testing.T) {
-	pr, err := makePullRequestInput(false, "https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "my-test-branch", "foo bar wibble")
+	pr, err := makePullRequestInput(false, "https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "master", "my-test-branch", "foo bar wibble")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -9,7 +9,15 @@ import (
 )
 
 func TestMakePullRequestInput(t *testing.T) {
-	pr, err := makePullRequestInput(false, "https://example.com/project/dev-env.git", "https://example.com/project/prod-env.git", "master", "my-test-branch", "foo bar wibble")
+	from := EnvLocale{
+		Path:   "https://example.com/project/dev-env.git",
+		Branch: "example",
+	}
+	to := EnvLocale{
+		Path:   "https://example.com/project/prod-env.git",
+		Branch: "master",
+	}
+	pr, err := makePullRequestInput(from, to, "my-test-branch", "foo bar wibble")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestMakePullRequestInput(t *testing.T) {
-	from := EnvLocale{
-		Path:   "https://example.com/project/dev-env.git",
-		Branch: "example",
+	from := EnvLocation{
+		RepoPath: "https://example.com/project/dev-env.git",
+		Branch:   "example",
 	}
-	to := EnvLocale{
-		Path:   "https://example.com/project/prod-env.git",
-		Branch: "master",
+	to := EnvLocation{
+		RepoPath: "https://example.com/project/prod-env.git",
+		Branch:   "master",
 	}
 	pr, err := makePullRequestInput(from, to, "my-test-branch", "foo bar wibble")
 	if err != nil {

--- a/pkg/promotion/service_manager.go
+++ b/pkg/promotion/service_manager.go
@@ -81,15 +81,12 @@ func WithRepoType(f string) serviceOpt {
 	}
 }
 
-// TODO: make this a command-line parameter defaulting to "master"
-const fromBranch = "master"
-
 // Promote is the main driver for promoting files between two
 // repositories.
 //
 // It uses a Git cache to checkout the code to, and will copy the environment
 // configuration for the `fromURL` to the `toURL` in a named branch.
-func (s *ServiceManager) Promote(serviceName, fromURL, toURL, newBranchName, message string, keepCache bool) error {
+func (s *ServiceManager) Promote(serviceName, fromURL, fromBranch, toURL, toBranch, newBranchName, message string, keepCache bool) error {
 	var source, destination git.Repo
 	var reposToDelete []git.Repo
 
@@ -189,7 +186,7 @@ func (s *ServiceManager) Promote(serviceName, fromURL, toURL, newBranchName, mes
 	}
 
 	ctx := context.Background()
-	pr, err := createPullRequest(ctx, fromURL, toURL, newBranchName, commitMsg, s.clientFactory(s.author.Token, toURL, s.repoType, s.tlsVerify), isLocal)
+	pr, err := createPullRequest(ctx, fromURL, toURL, toBranch, newBranchName, commitMsg, s.clientFactory(s.author.Token, toURL, s.repoType, s.tlsVerify), isLocal)
 	if err != nil {
 		message := fmt.Sprintf("failed to create a pull-request for branch %s, error: %s", newBranchName, err)
 		return git.GitError(message, toURL)
@@ -243,8 +240,8 @@ func (s *ServiceManager) cloneRepo(repoURL, branch string) (git.Repo, error) {
 	return repo, nil
 }
 
-func createPullRequest(ctx context.Context, fromURL, toURL, newBranchName, commitMsg string, client *scm.Client, fromLocal bool) (*scm.PullRequest, error) {
-	prInput, err := makePullRequestInput(fromLocal, fromURL, toURL, newBranchName, commitMsg)
+func createPullRequest(ctx context.Context, fromURL, toURL, toBranch, newBranchName, commitMsg string, client *scm.Client, fromLocal bool) (*scm.PullRequest, error) {
+	prInput, err := makePullRequestInput(fromLocal, fromURL, toURL, toBranch, newBranchName, commitMsg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/promotion/service_manager_test.go
+++ b/pkg/promotion/service_manager_test.go
@@ -63,7 +63,7 @@ func promoteWithSuccess(t *testing.T, keepCache bool, repoType string, tlsVerify
 	}
 	devRepo.AddFiles("services/my-service/base/config/myfile.yaml")
 	stagingRepo.AddFiles("")
-	err := sm.Promote("my-service", dev, staging, dstBranch, msg, keepCache)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, msg, keepCache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func promoteLocalWithSuccess(t *testing.T, keepCache bool, msg string) {
 	devRepo.AddFiles("config/myfile.yaml")
 	stagingRepo.AddFiles("staging")
 
-	err := sm.Promote("my-service", ldev, staging, dstBranch, msg, keepCache)
+	err := sm.Promote("my-service", ldev, "master", staging, "master", dstBranch, msg, keepCache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestPromoteLocalWithSuccessOneEnvAndIsUsed(t *testing.T) {
 	devRepo.AddFiles("/config/myfile.yaml")
 	stagingRepo.AddFiles("/staging")
 
-	err := sm.Promote("my-service", ldev, staging, dstBranch, "", false)
+	err := sm.Promote("my-service", ldev, "master", staging, "master", dstBranch, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestPromoteErrorsIfMultipleEnvironments(t *testing.T) {
 	devRepo.AddFiles("services/my-service/base/config/myfile.yaml")
 
 	msg := "foo message"
-	err := sm.Promote("my-service", dev, staging, dstBranch, msg, false)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, msg, false)
 	if err == nil {
 		t.Fail()
 	}
@@ -259,7 +259,7 @@ func TestPromoteWithCacheDeletionFailure(t *testing.T) {
 	devRepo.AddFiles("dev/services/my-service/base/config/myfile.yaml")
 	stagingRepo.AddFiles("staging")
 
-	err := sm.Promote("my-service", dev, staging, dstBranch, "", false)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func TestRepositoryCloneErrorOmitsToken(t *testing.T) {
 		errorMessage := fmt.Errorf("failed to clone repository %s: exit status 128", dev)
 		return nil, errorMessage
 	}
-	err := sm.Promote("my-service", dev, staging, dstBranch, "", false)
+	err := sm.Promote("my-service", dev, "master", staging, "master", dstBranch, "", false)
 	if err != nil {
 		devRepoToUseInError := fmt.Sprintf(".*%s", dev)
 		test.AssertErrorMatch(t, devRepoToUseInError, err)


### PR DESCRIPTION
In the discussion for #92, subcommands were suggested as a way to add the new functionality while keeping a clear user experience (by having fewer flags overall). This is all experimental and based off of my work from #106, so lots of details can and will change, but I wanted to post something that people could try out. For more background, see https://github.com/rhd-gitops-example/services/issues/92#issuecomment-641397247. 

Subcommand examples that this enables:
```
services promote env --from "dev" --to "staging" --repo "https://github.com/JustinKuli/gitops-example-multienv.git" --service "promote-demo" --commit-message "Test multienv subcommand"

services promote branch --from "dev-a" --to "dev-b" --repo "https://github.com/JustinKuli/gitops-example-dev.git" --service "promote-demo" --commit-message "Test branch subcommand"

services promote repo --from "https://github.com/JustinKuli/gitops-example-dev.git" --to "https://github.com/JustinKuli/gitops-example-staging.git" --service "promote-demo" --commit-message "Test repo subcommand"

services promote complex --from "https://github.com/JustinKuli/gitops-example-multienv.git" --from-env-folder staging --to "https://github.com/JustinKuli/gitops-example-dev.git" --to-branch dev-b --service "promote-demo" --commit-message "Test complex promote"
```

The `env` subcommand replaces the one I originally named `within`, as suggested by @a-roberts. The `repo` subcommand replaces the one I originally named `across`, which basically fulfills the interface we currently have in the CLI (before any of my changes).

The `complex` subcommand opens flags for all of the parameters, I don't think it's particularly necessary to keep it around but it is a neat example.

The implementation allows arbitrary/"complex" promotion paths inside of the `Promote` function itself, but the CLI (usually) exposes only a few at a time in each subcommand and fills in sensible defaults for the others.