### PR TITLE
Fail the automerge task when a problem occurs e.g. bad credentials

### DIFF
--- a/automerge-example/webhooks/templates/automerge-task.yaml
+++ b/automerge-example/webhooks/templates/automerge-task.yaml
@@ -34,8 +34,9 @@ spec:
   - name: merge-pr
     image: YOUR_DOCKER_HUB_ID/hub-test
     script: |
-      #!/bin/bash -x
-
+      #!/bin/bash -ex
+      # Intentionally use the -e here so we fail the PipelineRun if anything goes wrong 
+      # for example in the case of bad credentials being provided.
       if [ $(params.event-type) = "push" ]; then
         echo "git push on branch $(params.branch-name)"
         if [ $(params.branch-name) = "refs/heads/master" ]; then


### PR DESCRIPTION
Tiny one, closes https://github.com/rhd-gitops-example/services/issues/110

Tested by using good/bad credentials. With the good credentials it continues to pass and with the bad ones, `merge-pr` gets to:

```
+ '[' pull_request = push ']'
+ '[' pull_request = pull_request ']'
+ git config --global --add hub.host github.ibm.com
+ git config --global user.name a-roberts
+ git config --global user.email myemail
+ cd git-source
+ export HUB_VERBOSE=true
+ HUB_VERBOSE=true
+ hub merge https://github.ibm.com/AROBERTS/gitops-example-dev/pull/2
$ git config --get-all hub.host
> GET https://github.ibm.com/api/v3/user
> Authorization: token [REDACTED]
> Accept: application/vnd.github.v3+json;charset=utf-8
< HTTP 401
{"message":"Bad credentials","documentation_url":"https://developer.github.com/enterprise/2.19/v3"}
> GET https://github.ibm.com/api/v3/repos/AROBERTS/gitops-example-dev/pulls/2
> Authorization: token 
> Accept: application/vnd.github.v3+json;charset=utf-8
< HTTP 401
{"message":"Bad credentials","documentation_url":"https://developer.github.com/enterprise/2.19/v3"}
Error getting pull request: Unauthorized (HTTP 401)
Bad credentials
```