### PR TITLE
Support multiple environment folders and add subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,26 +68,34 @@ promote from one environment to another
 
 Usage:
   services promote [flags]
+  services promote [command]
+
+Available Commands:
+  branch      promote between branches within one repository
+  env         promote between environment folders within one repository
+  repo        promote between repositories
 
 Flags:
-      --branch-name string       the name of the branch on the destination repository for the pull request (auto-generated if empty)
+      --branch-name string       the branch on the destination repository for the pull request (auto-generated if empty)
       --cache-dir string         where to cache Git checkouts (default "~/.promotion/cache")
-      --commit-email string      the email to use for commits when creating branches
-      --commit-message string    the msg to use on the resultant commit and pull request
-      --commit-name string       the name to use for commits when creating branches
-      --debug                    additional debug logging output
-      --from string              source Git repository
-      --from-branch string       branch on the source Git repository (default "master")
+      --from string              the source Git repository (URL or local)
+      --from-branch string       the branch on the source Git repository (default "master")
+      --from-env-folder string   env folder on the source Git repository (if not provided, the repository should only have one folder under environments/)
   -h, --help                     help for promote
-      --insecure-skip-verify     Insecure skip verify TLS certificate
       --keep-cache               whether to retain the locally cloned repositories in the cache directory
-      --repository-type string   the type of repository: github, gitlab or ghe (default "github")
-      --service string           service name to promote
-      --to string                destination Git repository
-      --to-branch string         branch on the destination Git repository (default "master")
+      --service string           the name of the service to promote
+      --to string                the destination Git repository
+      --to-branch string         the branch on the destination Git repository (default "master")
+      --to-env-folder string     env folder on the destination Git repository (if not provided, the repository should only have one folder under environments/)
 
 Global Flags:
-      --github-token string   oauth access token to authenticate the request
+      --commit-email string      the email to use for commits when creating branches
+      --commit-message string    the message to use on the resultant commit and pull request
+      --commit-name string       the name to use for commits when creating branches
+      --debug                    additional debug logging output
+      --github-token string      oauth access token to authenticate the request
+      --insecure-skip-verify     Insecure skip verify TLS certificate
+      --repository-type string   the type of repository: github, gitlab or ghe (default "github")
 ```
 
 This will _copy_ all files under `/services/service-a/base/config/*` in `first-environment` to `second-environment`, commit and push, and open a PR for the change. Any of these arguments may be provided as environment variables, using all upper case and replacing `-` with `_`. Hence you can set CACHE_DIR, COMMIT_EMAIL, etc.
@@ -99,6 +107,7 @@ This will _copy_ all files under `/services/service-a/base/config/*` in `first-e
 - `--commit-name` : The other half of `commit-email`. Both must be set.
 - `--debug` : prints extra debug output if true.
 - `--from` : an https URL to a GitOps repository for 'remote' cases, or a path to a Git clone of a microservice for 'local' cases.
+- `--from-env` : use this to specify an environment folder in the source repository, for when you have more than one environment per repository. If this is not provided when the repository has more than one folder under `environments/`, then the operation will fail.
 - `--from-branch` : use this to specify a branch on the source repository, instead of using the "master" branch.
 - `--help`: prints the above text if true.
 - `--insecure-skip-verify` : skip TLS cerificate verification if true. Do not set this to true unless you know what you are doing.
@@ -106,7 +115,18 @@ This will _copy_ all files under `/services/service-a/base/config/*` in `first-e
 - `--repository-type` : the type of repository: github, gitlab or ghe (default "github"). If `--from` is a Git URL, it must be of the same type as that specified via `--to`.
 - `--service` : the destination path for promotion is `/environments/<env-name>/services/<service-name>/base/config/`. This argument defines `service-name` in that path.
 - `--to`: an https URL to the destination GitOps repository.
+- `--to-env` : use this to specify an environment folder in the destination repository, for when you have more than one environment per repository. If this is not provided when the repository has more than one folder under `environments/`, then the operation will fail.
 - `--to-branch` : use this to specify a branch on the destination repository, instead of using the "master" branch.
+
+### Promote Sub-commands
+The main promote commands provides a lot of flexibility with all of its options, but the subcommands provide a simpler interface for the usual promotion paths. For example, when promoting between environment folders in the same repository and branch, you could use either of these commands:
+``` bash
+services promote --from "https://github.com/example/my-gitops.git" --from-env-folder "dev" --to "https://github.com/example/my-gitops.git" --to-env-folder "prod" --service "example"
+
+# or
+
+services promote env --from "dev" --to "prod" --repo "https://github.com/example/my-gitops.git" --service "example"
+``` 
 
 ### Troubleshooting
 

--- a/pkg/cmd/promote_branch.go
+++ b/pkg/cmd/promote_branch.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rhd-gitops-example/services/pkg/promotion"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var promoteBranchCmd = &cobra.Command{
+	Use:   "branch",
+	Short: "promote between branches within one repository",
+	RunE:  promoteBranchAction,
+}
+
+func init() {
+	promoteCmd.AddCommand(promoteBranchCmd)
+
+	promoteBranchCmd.Flags().String(fromFlag, "", "the source branch")
+	promoteBranchCmd.Flags().String(toFlag, "", "the destination branch")
+	promoteBranchCmd.Flags().String(serviceFlag, "", "the name of the service to promote")
+	promoteBranchCmd.Flags().String(repoFlag, "", "the URL of the Git repository")
+
+	logIfError(promoteBranchCmd.MarkFlagRequired(fromFlag))
+	logIfError(promoteBranchCmd.MarkFlagRequired(toFlag))
+	logIfError(promoteBranchCmd.MarkFlagRequired(serviceFlag))
+	logIfError(promoteBranchCmd.MarkFlagRequired(repoFlag))
+}
+
+func promoteBranchAction(c *cobra.Command, args []string) error {
+	bindFlags(c.Flags(), []string{
+		fromFlag,
+		toFlag,
+		serviceFlag,
+		repoFlag,
+	})
+
+	fromBranch := viper.GetString(fromFlag)
+	toBranch := viper.GetString(toFlag)
+	service := viper.GetString(serviceFlag)
+	repo := viper.GetString(repoFlag)
+
+	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
+	keepCache := viper.GetBool(keepCacheFlag)
+
+	from := promotion.EnvLocation{
+		RepoPath: repo,
+		Branch:   fromBranch,
+		Folder:   "",
+	}
+	to := promotion.EnvLocation{
+		RepoPath: repo,
+		Branch:   toBranch,
+		Folder:   "",
+	}
+
+	sm, err := newServiceManager()
+	if err != nil {
+		return err
+	}
+
+	if msg == "" {
+		msg = fmt.Sprintf("Promote branch %s to %s", fromBranch, toBranch)
+	}
+
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
+}

--- a/pkg/cmd/promote_env.go
+++ b/pkg/cmd/promote_env.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rhd-gitops-example/services/pkg/promotion"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var promoteEnvCmd = &cobra.Command{
+	Use:   "env",
+	Short: "promote between environment folders within one repository",
+	RunE:  promoteEnvAction,
+}
+
+func init() {
+	promoteCmd.AddCommand(promoteEnvCmd)
+
+	promoteEnvCmd.Flags().String(fromFlag, "", "the source environment folder")
+	promoteEnvCmd.Flags().String(toFlag, "", "the destination environment folder")
+	promoteEnvCmd.Flags().String(serviceFlag, "", "the name of the service to promote")
+	promoteEnvCmd.Flags().String(repoFlag, "", "the URL of the Git repository")
+
+	logIfError(promoteEnvCmd.MarkFlagRequired(fromFlag))
+	logIfError(promoteEnvCmd.MarkFlagRequired(toFlag))
+	logIfError(promoteEnvCmd.MarkFlagRequired(serviceFlag))
+	logIfError(promoteEnvCmd.MarkFlagRequired(repoFlag))
+}
+
+func promoteEnvAction(c *cobra.Command, args []string) error {
+	bindFlags(c.Flags(), []string{
+		fromFlag,
+		toFlag,
+		serviceFlag,
+		repoFlag,
+	})
+
+	fromEnvFolder := viper.GetString(fromFlag)
+	toEnvFolder := viper.GetString(toFlag)
+	service := viper.GetString(serviceFlag)
+	repo := viper.GetString(repoFlag)
+
+	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
+	keepCache := viper.GetBool(keepCacheFlag)
+
+	from := promotion.EnvLocation{
+		RepoPath: repo,
+		Branch:   "master",
+		Folder:   fromEnvFolder,
+	}
+	to := promotion.EnvLocation{
+		RepoPath: repo,
+		Branch:   "master",
+		Folder:   toEnvFolder,
+	}
+
+	sm, err := newServiceManager()
+	if err != nil {
+		return err
+	}
+
+	if msg == "" {
+		msg = fmt.Sprintf("Promote environment %s to %s", fromEnvFolder, toEnvFolder)
+	}
+
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
+}

--- a/pkg/cmd/promote_repo.go
+++ b/pkg/cmd/promote_repo.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rhd-gitops-example/services/pkg/promotion"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var promoteRepoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "promote between repositories",
+	RunE:  promoteRepoAction,
+}
+
+func init() {
+	promoteCmd.AddCommand(promoteRepoCmd)
+
+	promoteRepoCmd.Flags().String(fromFlag, "", "the URL of the source repository")
+	promoteRepoCmd.Flags().String(toFlag, "", "the URL of the destination repository")
+	promoteRepoCmd.Flags().String(serviceFlag, "", "the name of the service to promote")
+
+	logIfError(promoteRepoCmd.MarkFlagRequired(fromFlag))
+	logIfError(promoteRepoCmd.MarkFlagRequired(toFlag))
+	logIfError(promoteRepoCmd.MarkFlagRequired(serviceFlag))
+}
+
+func promoteRepoAction(c *cobra.Command, args []string) error {
+	bindFlags(c.Flags(), []string{
+		fromFlag,
+		toFlag,
+		serviceFlag,
+	})
+
+	fromRepo := viper.GetString(fromFlag)
+	toRepo := viper.GetString(toFlag)
+	service := viper.GetString(serviceFlag)
+
+	newBranchName := viper.GetString(branchNameFlag)
+	msg := viper.GetString(msgFlag)
+	keepCache := viper.GetBool(keepCacheFlag)
+
+	from := promotion.EnvLocation{
+		RepoPath: fromRepo,
+		Branch:   "master",
+		Folder:   "",
+	}
+	to := promotion.EnvLocation{
+		RepoPath: toRepo,
+		Branch:   "master",
+		Folder:   "",
+	}
+
+	sm, err := newServiceManager()
+	if err != nil {
+		return err
+	}
+
+	if msg == "" {
+		msg = fmt.Sprintf("Promote repository %s to %s", fromRepo, toRepo)
+	}
+
+	return sm.Promote(service, from, to, newBranchName, msg, keepCache)
+}

--- a/pkg/git/mock/file_info.go
+++ b/pkg/git/mock/file_info.go
@@ -1,0 +1,40 @@
+package mock
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// satisfies the os.FileInfo interface for mocking
+type mockFileInfo struct {
+	name string
+}
+
+func newFileInfo(name string) mockFileInfo {
+	return mockFileInfo{name}
+}
+
+func (f mockFileInfo) Name() string {
+	return filepath.Base(f.name)
+}
+
+func (f mockFileInfo) Size() int64 {
+	return 8
+}
+
+func (f mockFileInfo) Mode() os.FileMode {
+	return os.ModeDir
+}
+
+func (f mockFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (f mockFileInfo) IsDir() bool {
+	return true
+}
+
+func (f mockFileInfo) Sys() interface{} {
+	return nil
+}

--- a/pkg/git/mock/mock.go
+++ b/pkg/git/mock/mock.go
@@ -96,9 +96,13 @@ func (m *Repository) Commit(msg string, author *git.Author) error {
 	return m.CommitErr
 }
 
-// Not implemented
 func (m *Repository) DirectoriesUnderPath(path string) ([]os.FileInfo, error) {
-	return nil, nil
+	// For easy mocking, returns all files "added" to this repo.
+	dirs := make([]os.FileInfo, len(m.files))
+	for i, f := range m.files {
+		dirs[i] = newFileInfo(f)
+	}
+	return dirs, nil
 }
 
 func (m *Repository) GetUniqueEnvironmentFolder() (string, error) {

--- a/pkg/git/repository_test.go
+++ b/pkg/git/repository_test.go
@@ -70,6 +70,16 @@ func TestClone(t *testing.T) {
 	}
 }
 
+func TestCloneIsIdempotent(t *testing.T) {
+	r, cleanup := cloneTestRepository(t)
+	defer cleanup()
+
+	err := r.Clone()
+	if err != nil {
+		t.Fatalf("failed to clone repository after it had already been cloned: %v", err)
+	}
+}
+
 func TestWalk(t *testing.T) {
 	r, cleanup := cloneTestRepository(t)
 	defer cleanup()

--- a/pkg/promotion/env_location.go
+++ b/pkg/promotion/env_location.go
@@ -1,0 +1,50 @@
+package promotion
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/rhd-gitops-example/services/pkg/util"
+)
+
+type EnvLocation struct {
+	RepoPath string // URL or local path
+	Branch   string
+	Folder   string
+}
+
+func (env EnvLocation) IsLocal() (bool, error) {
+	parsed, err := url.Parse(env.RepoPath)
+	if err != nil {
+		return false, fmt.Errorf("failed parsing URL for environment path: %w", err)
+	}
+	return parsed.Scheme == "", nil
+}
+
+// String implements Stringer so that messages (including logs, commits and PRs)
+// can reference EnvLocations consistently and in a more readable way.
+// When possible, it will shorten repository paths so that 'github.com/org/repo'
+// is just 'repo'. When not possible, it will use the entire URL.
+func (env EnvLocation) String() string {
+	var repoName string
+	local, err := env.IsLocal()
+	if err != nil {
+		repoName = env.RepoPath
+	} else {
+		_, repoName, err = util.ExtractUserAndRepo(env.RepoPath)
+		if err != nil {
+			repoName = env.RepoPath
+		}
+	}
+	if local {
+		return "local filesystem directory"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "branch %s in %s", env.Branch, repoName)
+	if env.Folder != "" {
+		fmt.Fprintf(&b, " (environment folder %s)", env.Folder)
+	}
+	return b.String()
+}

--- a/pkg/promotion/promote_test.go
+++ b/pkg/promotion/promote_test.go
@@ -1,0 +1,242 @@
+package promotion
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jenkins-x/go-scm/scm"
+	fakescm "github.com/jenkins-x/go-scm/scm/driver/fake"
+	"github.com/rhd-gitops-example/services/pkg/git"
+	"github.com/rhd-gitops-example/services/pkg/git/mock"
+)
+
+const (
+	exampleDevRepo         = "https://github.com/rhd-gitops-example/gitops-example-dev.git"
+	exampleStagingRepo     = "https://github.com/rhd-gitops-example/gitops-example-staging.git"
+	exampleAlternativeRepo = "https://github.com/JustinKuli/gitops-alternative-layouts.git"
+	// TODO: move this ^ out of a personal github?
+)
+
+var (
+	dev_repo           = EnvLocation{exampleDevRepo, "master", ""}
+	staging_repo       = EnvLocation{exampleStagingRepo, "master", ""}
+	team_a_branch      = EnvLocation{exampleAlternativeRepo, "team-a", ""}
+	team_b_branch      = EnvLocation{exampleAlternativeRepo, "team-b", ""}
+	dev_env            = EnvLocation{exampleAlternativeRepo, "main", "dev"}
+	staging_env        = EnvLocation{exampleAlternativeRepo, "main", "staging"}
+	teams_branch_a_env = EnvLocation{exampleAlternativeRepo, "team-envs", "team-a"}
+)
+
+func TestRepoPromotionPath(t *testing.T) {
+	promotionPath(t, dev_repo, staging_repo, "dev")
+}
+func TestBranchPromotionPath(t *testing.T) {
+	promotionPath(t, team_a_branch, team_b_branch, "dev")
+}
+func TestEnvPromotionPath(t *testing.T) {
+	promotionPath(t, dev_env, staging_env, "dev")
+}
+func TestToMultiEnvAcrossBranchesPromotionPath(t *testing.T) {
+	promotionPath(t, team_a_branch, staging_env, "dev")
+}
+func TestToMultiEnvAcrossReposPromotionPath(t *testing.T) {
+	promotionPath(t, dev_repo, staging_env, "dev")
+}
+func TestFromMultiEnvAcrossReposPromotionPath(t *testing.T) {
+	promotionPath(t, teams_branch_a_env, dev_repo, "team-a")
+}
+func TestMultiEnvToMultiEnvAcrossReposPromotionPath(t *testing.T) {
+	promotionPath(t, teams_branch_a_env, dev_env, "team-a")
+}
+
+func promotionPath(t *testing.T, from, to EnvLocation, fromEnv string) {
+	t.Helper()
+	src, dest, clean := mustGetCaches(t, from, to)
+	defer clean()
+
+	author := &git.Author{Name: "Testing User", Email: "testing@example.com", Token: "test-token"}
+	srcURL := mustAddCredentials(t, from.RepoPath, author)
+	destURL := mustAddCredentials(t, to.RepoPath, author)
+	fakeSCMClient, _ := fakescm.NewDefault()
+
+	sm := New("tmp", author)
+	sm.clientFactory = func(s, ty, r string, v bool) *scm.Client {
+		return fakeSCMClient
+	}
+	sm.repoFactory = func(url, localPath string, v bool, _ bool) (git.Repo, error) {
+		if url == srcURL && strings.HasSuffix(localPath, neturl.QueryEscape(from.Branch)) {
+			return src, nil
+		}
+		if url == destURL { // This needs to handle newly created branches as well as the original destination
+			return dest, nil
+		}
+		return nil, errors.New("Attempted to clone a repository the tests didn't specially prepare.")
+	}
+
+	testFileName := mustAddTestFile(t, src, fromEnv, "service-a", author)
+
+	err := sm.Promote("service-a", from, to, "", "", true)
+	if err != nil {
+		t.Fatal("Promote failed unexpectedly: ", err)
+	}
+
+	assertTestFilePresent(t, dest, testFileName)
+	assertPullRequestCorrect(t, fakeSCMClient, to.Branch)
+}
+
+func mustGetCaches(t *testing.T, from, to EnvLocation) (src, dest *git.Repository, clean func()) {
+	t.Helper()
+	src, cleanSrc, err := getNewCacheOf(from)
+	if err != nil {
+		if er := cleanSrc(); er != nil {
+			t.Errorf("failed to clean cache for %#v: %v", from, er)
+		}
+		t.Fatalf("failed to create cache for %#v: %v", from, err)
+	}
+	dest, cleanDest, err := getNewCacheOf(to)
+	clean = func() {
+		if er := cleanSrc(); er != nil {
+			t.Errorf("failed to clean cache for %#v: %v", from, er)
+		}
+		if er := cleanDest(); er != nil {
+			t.Errorf("failed to clean cache for %#v: %v", to, er)
+		}
+	}
+	if err != nil {
+		clean()
+		t.Fatalf("failed to create cache for %#v: %v", to, err)
+	}
+	return src, dest, clean
+}
+
+func getNewCacheOf(l EnvLocation) (r *git.Repository, clean func() error, err error) {
+	clean = func() error { return nil } // no-op in case we return early.
+	dir, err := ioutil.TempDir(os.TempDir(), "promote")
+	if err != nil {
+		return nil, clean, err
+	}
+	clean = func() error {
+		return os.RemoveAll(dir)
+	}
+
+	r, err = git.NewRepository(l.RepoPath, dir, true, true)
+	if err != nil {
+		return r, clean, err
+	}
+	r.DisablePush() // Don't pollute the repositories with new commits/branches
+	err = r.Clone()
+	if err != nil {
+		return r, clean, err
+	}
+	err = r.Checkout(l.Branch)
+	return r, clean, err
+}
+
+func mustAddTestFile(t *testing.T, r *git.Repository, env, svc string, author *git.Author) string {
+	t.Helper()
+	f, err := ioutil.TempFile(os.TempDir(), "test")
+	if err != nil {
+		t.Fatal("failed to create temporary test file: ", err)
+	}
+	defer func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			t.Fatal("failed to remove temporary test file: ", err)
+		}
+	}()
+
+	filename := filepath.Base(f.Name())
+	pathInRepo := filepath.Join("environments", env, "", "services", svc, "base", "config", filename)
+	err = r.CopyFile(f.Name(), pathInRepo)
+	if err != nil {
+		t.Fatalf("failed to copy test file to %s in repository %v: %v", pathInRepo, r, err)
+	}
+
+	err = r.StageFiles(pathInRepo)
+	if err != nil {
+		t.Fatalf("failed to stage test file in repository %v: %v", r, err)
+	}
+	err = r.Commit("Add test file for unit test", author)
+	if err != nil {
+		t.Fatalf("failed to commit test file in repository %v: %v", r, err)
+	}
+
+	return filename
+}
+
+func assertTestFilePresent(t *testing.T, repo git.Source, filename string) {
+	t.Helper()
+	found := false
+	err := repo.Walk(".", func(prefix, name string) error {
+		if filepath.Base(name) == filename {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("error while walking through repository %v: %v", repo, err)
+	}
+	if !found {
+		t.Fatal("Test file not found in destination repo cache")
+	}
+}
+
+func assertPullRequestCorrect(t *testing.T, client *scm.Client, wantBase string) {
+	t.Helper()
+	pr, _, err := client.PullRequests.Find(context.Background(), "", 1)
+	if err != nil {
+		t.Fatal("Pull request not found")
+	}
+
+	if wantBase != pr.Base.Ref {
+		t.Errorf("Pull Request Base got '%s', want '%s'", pr.Base.Ref, wantBase)
+	}
+}
+
+func TestGetEnvironmentFolder(t *testing.T) {
+	noFolders := mock.New("nonePath", "master")
+	oneFolder := mock.New("onePath", "master")
+	oneFolder.AddFiles("example")
+	twoFolders := mock.New("twoPath", "master")
+	twoFolders.AddFiles("example")
+	twoFolders.AddFiles("another")
+
+	// Tests various configurations of the repository and inputs to the function.
+	// For example, if there are no environment folders in the repository, we should
+	// fail every time. If there are multiple folders, then the function should only
+	// succeed if we specify one that actually exists
+	tests := []struct {
+		repo           git.Repo
+		checkFolder    string
+		expectedFolder string
+		expectedError  bool
+	}{
+		{noFolders, "", "", true},
+		{noFolders, "example", "", true},
+		{oneFolder, "", "example", false},
+		{oneFolder, "example", "example", false}, // input matches actual folder
+		{oneFolder, "another", "", true},         // input folder doesn't match actual folder
+		{twoFolders, "", "", true},
+		{twoFolders, "example", "example", false},
+		{twoFolders, "another", "another", false},
+		{twoFolders, "fake", "", true}, // input does not match an actual folder
+	}
+
+	for _, test := range tests {
+		f, err := getEnvironmentFolder(test.repo, test.checkFolder)
+		if test.expectedError && err == nil {
+			t.Errorf("getEnvironmentFolder(%+v, '%v') gave nil err, but we wanted an error.", test.repo, test.checkFolder)
+		} else if !test.expectedError && err != nil {
+			t.Errorf("getEnvironmentFolder(%+v, '%v') gave error '%v', but we wanted no error.", test.repo, test.checkFolder, err)
+		}
+		if f != test.expectedFolder {
+			t.Errorf("getEnvironmentFolder(%+v, '%v') gave folder '%v', but we wanted '%v'.", test.repo, test.checkFolder, f, test.expectedFolder)
+		}
+	}
+}

--- a/pkg/promotion/pull_request.go
+++ b/pkg/promotion/pull_request.go
@@ -1,35 +1,15 @@
 package promotion
 
 import (
-	"fmt"
-
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/rhd-gitops-example/services/pkg/util"
 )
 
 // TODO: OptionFunc for Title?
 // TODO: For the Head, should this try and determine whether or not this is a
 // fork ("user" of both repoURLs) and if so, simplify the Head?
 func makePullRequestInput(from, to EnvLocation, branchName, prBody string) (*scm.PullRequestInput, error) {
-	var title string
-
-	_, toRepo, err := util.ExtractUserAndRepo(to.RepoPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if from.IsLocal() {
-		title = fmt.Sprintf("promotion from local filesystem directory to %s", toRepo)
-	} else {
-		_, fromRepo, err := util.ExtractUserAndRepo(from.RepoPath)
-		if err != nil {
-			return nil, err
-		}
-		title = fmt.Sprintf("promotion from %s to %s", fromRepo, toRepo)
-	}
-
 	return &scm.PullRequestInput{
-		Title: title,
+		Title: prBody,
 		Head:  branchName,
 		Base:  to.Branch,
 		Body:  prBody,

--- a/pkg/promotion/pull_request_test.go
+++ b/pkg/promotion/pull_request_test.go
@@ -23,7 +23,7 @@ func TestMakePullRequestInput(t *testing.T) {
 	}
 
 	want := &scm.PullRequestInput{
-		Title: "promotion from dev-env to prod-env",
+		Title: "foo bar wibble",
 		Head:  "my-test-branch",
 		Base:  "master",
 		Body:  "foo bar wibble",

--- a/pkg/promotion/service_manager_test.go
+++ b/pkg/promotion/service_manager_test.go
@@ -80,7 +80,7 @@ func promoteWithSuccess(t *testing.T, keepCache bool, repoType string, tlsVerify
 	expectedCommitMsg := msg
 	if msg == "" {
 		commit := devRepo.GetCommitID()
-		expectedCommitMsg = fmt.Sprintf("Promoting service my-service at commit %s from branch master in %s.", commit, dev.RepoPath)
+		expectedCommitMsg = fmt.Sprintf("Promote service my-service at commit %s from %v", commit, dev)
 	}
 
 	stagingRepo.AssertBranchCreated(t, "master", dstBranch)
@@ -137,7 +137,7 @@ func promoteLocalWithSuccess(t *testing.T, keepCache bool, msg string) {
 
 	expectedCommitMsg := msg
 	if expectedCommitMsg == "" {
-		expectedCommitMsg = "Promoting service my-service from local filesystem directory /root/repo."
+		expectedCommitMsg = "Promote service my-service from local filesystem directory /root/repo"
 	}
 
 	stagingRepo.AssertBranchCreated(t, "master", dstBranch)
@@ -179,7 +179,7 @@ func TestPromoteLocalWithSuccessOneEnvAndIsUsed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedCommitMsg := "Promoting service my-service from local filesystem directory /root/repo."
+	expectedCommitMsg := "Promote service my-service from local filesystem directory /root/repo"
 
 	stagingRepo.AssertBranchCreated(t, "master", dstBranch)
 	stagingRepo.AssertFileCopiedInBranch(t, dstBranch, "/dev/config/myfile.yaml", "environments/staging/services/my-service/base/config/myfile.yaml")
@@ -274,7 +274,7 @@ func TestPromoteWithCacheDeletionFailure(t *testing.T) {
 	}
 
 	commit := devRepo.GetCommitID()
-	expectedCommitMsg := fmt.Sprintf("Promoting service my-service at commit %s from branch master in %s.", commit, dev.RepoPath)
+	expectedCommitMsg := fmt.Sprintf("Promote service my-service at commit %s from %v", commit, dev)
 
 	stagingRepo.AssertBranchCreated(t, "master", dstBranch)
 	stagingRepo.AssertFileCopiedInBranch(t, dstBranch, "environments/dev/services/my-service/base/config/myfile.yaml", "environments/staging/services/my-service/base/config/myfile.yaml")


### PR DESCRIPTION
Main discussion in #92.

Added functional `--from-env` and `--to-env` flags on the usual promote command, and added new subcommands to simplify the experience when promoting along the "usual" paths:
- `services promote env <--from> <--to> <--repo> <--service>` 
- `services promote branch <--from> <--to> <--repo> <--service>`
- `services promote repo <--from> <--to> <--service>`

There was a bit of refactoring to try to prevent repetition in the new subcommands and keep things organized.

I found that I needed to re-bind the flags at the beginning of each "Action" function, otherwise only some subcommands would have the flags set correctly. I think it is something to do with the order that the `init` functions are executed in. The solution here was based on this comment: https://github.com/spf13/cobra/pull/299#issuecomment-317159677

To test this, you'll need multiple repositories set up for multiple branches and environment folders. I have examples you can clone as needed:
- multiple branches: https://github.com/JustinKuli/gitops-example-dev
- multiple environment folders: https://github.com/JustinKuli/gitops-example-multienv

These examples should demonstrate the usage (in addition to what's in the README):
```
services promote env --repo "https://github.com/JustinKuli/gitops-example-multienv.git" --from "dev" --to "staging" --service "promote-demo" --commit-message "Test multienv subcommand"

services promote branch --repo "https://github.com/JustinKuli/gitops-example-dev.git" --from "dev-a" --to "dev-b" --service "promote-demo" --commit-message "Test branch subcommand"

services promote repo --from "https://github.com/JustinKuli/gitops-example-dev.git" --to "https://github.com/JustinKuli/gitops-example-staging.git" --service "promote-demo" --commit-message "Test repo subcommand"

services promote --from "https://github.com/JustinKuli/gitops-example-multienv.git" --from-env-folder staging --to "https://github.com/JustinKuli/gitops-example-dev.git" --to-branch dev-b --service "promote-demo" --commit-message "Test complex promote"
```